### PR TITLE
Look only at external dependencies

### DIFF
--- a/src/test/fixtures/project-dependency/base/build.gradle
+++ b/src/test/fixtures/project-dependency/base/build.gradle
@@ -1,0 +1,15 @@
+apply plugin: 'com.android.application'
+apply plugin: 'app.cash.better.dynamic.features'
+apply plugin: 'org.jetbrains.kotlin.android'
+
+android {
+  namespace "app.cash.better.dynamic.features.integration"
+
+  compileSdk 32
+
+  dynamicFeatures = [':feature']
+}
+
+dependencies {
+  implementation "com.squareup.okhttp3:okhttp:4.9.3"
+}

--- a/src/test/fixtures/project-dependency/build.gradle
+++ b/src/test/fixtures/project-dependency/build.gradle
@@ -1,0 +1,13 @@
+buildscript {
+  apply from: "${projectDir.absolutePath}/../buildscript.gradle"
+}
+
+allprojects {
+  repositories {
+    maven {
+      url "file://${rootDir}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+}

--- a/src/test/fixtures/project-dependency/feature/build.gradle
+++ b/src/test/fixtures/project-dependency/feature/build.gradle
@@ -1,0 +1,13 @@
+apply plugin: 'com.android.dynamic-feature'
+apply plugin: 'org.jetbrains.kotlin.android'
+
+android {
+  namespace "app.cash.better.dynamic.features.integration.feature"
+
+  compileSdk 32
+}
+
+dependencies {
+  implementation "com.squareup.okhttp3:okhttp:4.9.3"
+  implementation project(":library")
+}

--- a/src/test/fixtures/project-dependency/gradle.properties
+++ b/src/test/fixtures/project-dependency/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
+android.useAndroidX=true

--- a/src/test/fixtures/project-dependency/library/build.gradle
+++ b/src/test/fixtures/project-dependency/library/build.gradle
@@ -1,0 +1,1 @@
+apply plugin: 'org.jetbrains.kotlin.jvm'

--- a/src/test/fixtures/project-dependency/library/src/main/kotlin/com/example/HelloWorld.kt
+++ b/src/test/fixtures/project-dependency/library/src/main/kotlin/com/example/HelloWorld.kt
@@ -1,0 +1,5 @@
+// Copyright Square, Inc.
+// Copyright Square, Inc.
+fun helloWorld() {
+  println("Hello World!")
+}

--- a/src/test/fixtures/project-dependency/settings.gradle
+++ b/src/test/fixtures/project-dependency/settings.gradle
@@ -1,0 +1,5 @@
+apply from: "../settings.gradle"
+
+include ':base'
+include ':feature'
+include ':library'

--- a/src/test/fixtures/transitive-dependency/base/build.gradle
+++ b/src/test/fixtures/transitive-dependency/base/build.gradle
@@ -1,0 +1,15 @@
+apply plugin: 'com.android.application'
+apply plugin: 'app.cash.better.dynamic.features'
+apply plugin: 'org.jetbrains.kotlin.android'
+
+android {
+  namespace "app.cash.better.dynamic.features.integration"
+
+  compileSdk 32
+
+  dynamicFeatures = [':feature']
+}
+
+dependencies {
+  implementation "com.squareup.okhttp3:okhttp:4.9.3"
+}

--- a/src/test/fixtures/transitive-dependency/build.gradle
+++ b/src/test/fixtures/transitive-dependency/build.gradle
@@ -1,0 +1,13 @@
+buildscript {
+  apply from: "${projectDir.absolutePath}/../buildscript.gradle"
+}
+
+allprojects {
+  repositories {
+    maven {
+      url "file://${rootDir}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+}

--- a/src/test/fixtures/transitive-dependency/feature/build.gradle
+++ b/src/test/fixtures/transitive-dependency/feature/build.gradle
@@ -1,0 +1,13 @@
+apply plugin: 'com.android.dynamic-feature'
+apply plugin: 'org.jetbrains.kotlin.android'
+
+android {
+  namespace "app.cash.better.dynamic.features.integration.feature"
+
+  compileSdk 32
+}
+
+dependencies {
+  implementation "com.squareup.okhttp3:okhttp:4.9.3"
+  implementation project(":library")
+}

--- a/src/test/fixtures/transitive-dependency/gradle.properties
+++ b/src/test/fixtures/transitive-dependency/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
+android.useAndroidX=true

--- a/src/test/fixtures/transitive-dependency/library/build.gradle
+++ b/src/test/fixtures/transitive-dependency/library/build.gradle
@@ -1,0 +1,5 @@
+apply plugin: 'org.jetbrains.kotlin.jvm'
+
+dependencies {
+  implementation "com.squareup.okhttp3:okhttp:5.0.0-alpha.2"
+}

--- a/src/test/fixtures/transitive-dependency/library/src/main/kotlin/com/example/HelloWorld.kt
+++ b/src/test/fixtures/transitive-dependency/library/src/main/kotlin/com/example/HelloWorld.kt
@@ -1,0 +1,5 @@
+// Copyright Square, Inc.
+// Copyright Square, Inc.
+fun helloWorld() {
+  println("Hello World!")
+}

--- a/src/test/fixtures/transitive-dependency/settings.gradle
+++ b/src/test/fixtures/transitive-dependency/settings.gradle
@@ -1,0 +1,5 @@
+apply from: "../settings.gradle"
+
+include ':base'
+include ':feature'
+include ':library'

--- a/src/test/java/app/cash/better/dynamic/features/BetterDynamicFeaturesPluginTest.kt
+++ b/src/test/java/app/cash/better/dynamic/features/BetterDynamicFeaturesPluginTest.kt
@@ -53,4 +53,27 @@ class BetterDynamicFeaturesPluginTest {
     // Undo that
     baseGradle.writeText(baseGradle.readText().replace("5.0.0-alpha.2", "4.9.3"))
   }
+
+  @Test fun `conflict check does not build project module dependencies`() {
+    val integrationRoot = File("src/test/fixtures/project-dependency")
+
+    val gradleRunner = GradleRunner.create()
+      .withCommonConfiguration(integrationRoot)
+      .withArguments("clean", "checkDebugDependencyVersions")
+
+    val result = gradleRunner.build()
+    assertThat(result.output).contains("BUILD SUCCESSFUL")
+    assertThat(result.task(":library:jar")?.outcome).isNull()
+  }
+
+  @Test fun `conflict check looks at transitive dependencies`() {
+    val integrationRoot = File("src/test/fixtures/transitive-dependency")
+
+    val gradleRunner = GradleRunner.create()
+      .withCommonConfiguration(integrationRoot)
+      .withArguments("clean", "checkDebugDependencyVersions")
+
+    val result = gradleRunner.buildAndFail()
+    assertThat(result.output).contains("com.squareup.okhttp3:okhttp, :base=4.9.3, :feature=5.0.0-alpha.2 -> Use 5.0.0-alpha.2")
+  }
 }


### PR DESCRIPTION
This avoids an entire project build before looking at conflicts

Fixes #6 