### PR TITLE
Add handling of missing lockfile to check task

### DIFF
--- a/src/main/kotlin/app/cash/better/dynamic/features/BetterDynamicFeaturesPlugin.kt
+++ b/src/main/kotlin/app/cash/better/dynamic/features/BetterDynamicFeaturesPlugin.kt
@@ -57,7 +57,7 @@ class BetterDynamicFeaturesPlugin : Plugin<Project> {
 
       val checkLockfileTask =
         project.tasks.register("checkLockfile", CheckLockfileTask::class.java) { task ->
-          task.currentLockfile = realLockfile
+          task.currentLockfilePath = realLockfile
           task.newLockfile = tempLockfile
           task.outputFile = project.buildDir.resolve("tmp/lockfile_check")
 

--- a/src/main/kotlin/app/cash/better/dynamic/features/tasks/CheckLockfileTask.kt
+++ b/src/main/kotlin/app/cash/better/dynamic/features/tasks/CheckLockfileTask.kt
@@ -2,6 +2,8 @@ package app.cash.better.dynamic.features.tasks
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.File
@@ -12,18 +14,22 @@ abstract class CheckLockfileTask : DefaultTask() {
   @get:InputFile
   abstract var newLockfile: File
 
-  @get:InputFile
-  abstract var currentLockfile: File
+  @get:Internal
+  abstract var currentLockfilePath: File
+
+  @get:[Optional InputFile]
+  val currentLockfile: File?
+    get() = currentLockfilePath.takeIf { it.exists() }
 
   @get:OutputFile
   abstract var outputFile: File
 
   @TaskAction
   fun checkLockfiles() {
-    val areTheyEqual = newLockfile.readText() == currentLockfile.readText()
+    val areTheyEqual = newLockfile.readText() == currentLockfile?.readText()
     outputFile.writeText(areTheyEqual.toString())
     if (!areTheyEqual) {
-      Files.copy(newLockfile.toPath(), currentLockfile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+      Files.copy(newLockfile.toPath(), currentLockfilePath.toPath(), StandardCopyOption.REPLACE_EXISTING)
       throw IllegalStateException("The lockfile was out of date and has been updated. Rerun your build.")
     }
   }


### PR DESCRIPTION
If there hasn't been a lockfile generated for a project yet when the `checkLockfile` task runs, gradle will complain about an invalid `InputFile` input since the current lockfile doesn't exist.

This just adds some nicer handling for this case by marking the property as optional and setting it to null if the file doesn't exist, and updates the lockfile (by actually creating it) like we would for any `checkLockfile` run where the lockfile has changed.