### PR TITLE
Activate lockfiles only on base module

### DIFF
--- a/src/main/kotlin/app/cash/better/dynamic/features/BetterDynamicFeaturesPlugin.kt
+++ b/src/main/kotlin/app/cash/better/dynamic/features/BetterDynamicFeaturesPlugin.kt
@@ -81,6 +81,14 @@ class BetterDynamicFeaturesPlugin : Plugin<Project> {
     }
 
     project.setupListingTask(androidComponents)
+    androidComponents.onVariants { variant ->
+      // We only want to enforce the lockfile if we aren't explicitly trying to update it
+      if (project.gradle.startParameter.taskNames.none { "writeLockfile" in it }) {
+        project.configurations.named("${variant.name}RuntimeClasspath").configure {
+          it.resolutionStrategy.activateDependencyLocking()
+        }
+      }
+    }
   }
 
   private fun Project.setupListingTask(androidComponents: AndroidComponentsExtension<*, *, *>) {
@@ -88,10 +96,6 @@ class BetterDynamicFeaturesPlugin : Plugin<Project> {
 
     androidComponents.onVariants { variant ->
       variantNames += variant.name
-
-      configurations.named("${variant.name}RuntimeClasspath").configure {
-        it.resolutionStrategy.activateDependencyLocking()
-      }
     }
 
     afterEvaluate {


### PR DESCRIPTION
Prior to this change we activated lockfiles on both the application and feature modules, however we weren't generating any lockfiles for the feature modules. Since there's no trickery going on with the feature module's dependency graph, I don't think there's any point to us enforcing lockfiles on those modules, but if we want them then there's no reason they couldn't be enabled, generated and managed using gradle's built-in lockfile management. They're just regular modules at that point. Now we only activate them on the base module.

This change also deactivates lockfiles if the `writeLockfile` task is being run. This emulates the behaviour of the `--write-locks` flag since if we try to run the `writeLockfile` task while the lockfile is out of sync with the dependency graph then the task run will fail at configuration time and we end up in a deadlock unable to update our lockfile.