### PR TITLE
Fix configuration entries in generated lockfile

### DIFF
--- a/src/main/kotlin/app/cash/better/dynamic/features/tasks/LockfileEntry.kt
+++ b/src/main/kotlin/app/cash/better/dynamic/features/tasks/LockfileEntry.kt
@@ -1,13 +1,11 @@
 package app.cash.better.dynamic.features.tasks
 
-import java.util.SortedSet
-
 data class LockfileEntry(
   val artifact: String,
   val version: String,
-  val configurations: SortedSet<String>,
+  val configurations: Set<String>,
 ) : Comparable<LockfileEntry> {
   override fun compareTo(other: LockfileEntry): Int = this.toString().compareTo(other.toString())
 
-  override fun toString(): String = "$artifact:$version=${configurations.joinToString()}"
+  override fun toString(): String = "$artifact:$version=${configurations.sorted().joinToString(separator = ",")}"
 }

--- a/src/main/kotlin/app/cash/better/dynamic/features/tasks/PartialLockfileWriterTask.kt
+++ b/src/main/kotlin/app/cash/better/dynamic/features/tasks/PartialLockfileWriterTask.kt
@@ -2,6 +2,7 @@
 package app.cash.better.dynamic.features.tasks
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.Project
 import org.gradle.api.artifacts.ResolvedConfiguration
 import org.gradle.api.artifacts.ResolvedDependency
 import org.gradle.api.file.ConfigurableFileCollection
@@ -26,12 +27,12 @@ abstract class PartialLockfileWriterTask : DefaultTask() {
     resolvedLockfileEntries = provider.map { configurationMap ->
       configurationMap.flatMap { (configuration, resolved) ->
         buildSet { resolved.firstLevelModuleDependencies.walkDependencyTree { add(it) } }
-          .filter { it.moduleGroup != rootProjectName }
+          .filter { dependency -> dependency.moduleVersion != Project.DEFAULT_VERSION }
           .map {
             LockfileEntry(
               "${it.moduleGroup}:${it.moduleName}",
               it.moduleVersion,
-              sortedSetOf("${configuration}RuntimeClasspath"),
+              setOf("${configuration}RuntimeClasspath"),
             )
           }
       }

--- a/src/test/fixtures/different-versions-in-base/base/build.gradle
+++ b/src/test/fixtures/different-versions-in-base/base/build.gradle
@@ -1,0 +1,15 @@
+apply plugin: 'com.android.application'
+apply plugin: 'app.cash.better.dynamic.features'
+
+android {
+  namespace "app.cash.better.dynamic.features.integration"
+
+  compileSdk 32
+
+  dynamicFeatures = [':feature']
+}
+
+dependencies {
+  debugImplementation "com.squareup.okhttp3:okhttp:4.9.3"
+  releaseImplementation "com.squareup.okhttp3:okhttp:5.0.0-alpha.2"
+}

--- a/src/test/fixtures/different-versions-in-base/build.gradle
+++ b/src/test/fixtures/different-versions-in-base/build.gradle
@@ -1,0 +1,13 @@
+buildscript {
+  apply from: "${projectDir.absolutePath}/../buildscript.gradle"
+}
+
+allprojects {
+  repositories {
+    maven {
+      url "file://${rootDir}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+}

--- a/src/test/fixtures/different-versions-in-base/feature/build.gradle
+++ b/src/test/fixtures/different-versions-in-base/feature/build.gradle
@@ -1,0 +1,12 @@
+apply plugin: 'com.android.dynamic-feature'
+apply plugin: 'app.cash.better.dynamic.features'
+
+android {
+  namespace "app.cash.better.dynamic.features.integration.feature"
+
+  compileSdk 32
+}
+
+dependencies {
+  implementation project(":base")
+}

--- a/src/test/fixtures/different-versions-in-base/gradle.properties
+++ b/src/test/fixtures/different-versions-in-base/gradle.properties
@@ -1,0 +1,3 @@
+# Copyright Square, Inc.
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
+android.useAndroidX=true

--- a/src/test/fixtures/different-versions-in-base/settings.gradle
+++ b/src/test/fixtures/different-versions-in-base/settings.gradle
@@ -1,0 +1,4 @@
+apply from: "../settings.gradle"
+
+include ':base'
+include ':feature'

--- a/src/test/fixtures/out-of-date/base/gradle.lockfile.original
+++ b/src/test/fixtures/out-of-date/base/gradle.lockfile.original
@@ -1,9 +1,9 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.squareup.okhttp3:okhttp:4.9.3=debugRuntimeClasspath, releaseRuntimeClasspath
-com.squareup.okio:okio:2.8.0=debugRuntimeClasspath, releaseRuntimeClasspath
-org.jetbrains.kotlin:kotlin-stdlib-common:1.4.10=debugRuntimeClasspath, releaseRuntimeClasspath
-org.jetbrains.kotlin:kotlin-stdlib:1.4.10=debugRuntimeClasspath, releaseRuntimeClasspath
-org.jetbrains:annotations:13.0=debugRuntimeClasspath, releaseRuntimeClasspath
+com.squareup.okhttp3:okhttp:4.9.3=debugRuntimeClasspath,releaseRuntimeClasspath
+com.squareup.okio:okio:2.8.0=debugRuntimeClasspath,releaseRuntimeClasspath
+org.jetbrains.kotlin:kotlin-stdlib-common:1.4.10=debugRuntimeClasspath,releaseRuntimeClasspath
+org.jetbrains.kotlin:kotlin-stdlib:1.4.10=debugRuntimeClasspath,releaseRuntimeClasspath
+org.jetbrains:annotations:13.0=debugRuntimeClasspath,releaseRuntimeClasspath
 empty=

--- a/src/test/fixtures/out-of-date/base/gradle.lockfile.updated
+++ b/src/test/fixtures/out-of-date/base/gradle.lockfile.updated
@@ -1,9 +1,9 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.squareup.okhttp3:okhttp:5.0.0-alpha.2=debugRuntimeClasspath, releaseRuntimeClasspath
-com.squareup.okio:okio:2.9.0=debugRuntimeClasspath, releaseRuntimeClasspath
-org.jetbrains.kotlin:kotlin-stdlib-common:1.4.21=debugRuntimeClasspath, releaseRuntimeClasspath
-org.jetbrains.kotlin:kotlin-stdlib:1.4.21=debugRuntimeClasspath, releaseRuntimeClasspath
-org.jetbrains:annotations:13.0=debugRuntimeClasspath, releaseRuntimeClasspath
+com.squareup.okhttp3:okhttp:5.0.0-alpha.2=debugRuntimeClasspath,releaseRuntimeClasspath
+com.squareup.okio:okio:2.9.0=debugRuntimeClasspath,releaseRuntimeClasspath
+org.jetbrains.kotlin:kotlin-stdlib-common:1.4.21=debugRuntimeClasspath,releaseRuntimeClasspath
+org.jetbrains.kotlin:kotlin-stdlib:1.4.21=debugRuntimeClasspath,releaseRuntimeClasspath
+org.jetbrains:annotations:13.0=debugRuntimeClasspath,releaseRuntimeClasspath
 empty=

--- a/src/test/fixtures/up-to-date/base/gradle.lockfile
+++ b/src/test/fixtures/up-to-date/base/gradle.lockfile
@@ -1,9 +1,9 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.squareup.okhttp3:okhttp:5.0.0-alpha.2=debugRuntimeClasspath, releaseRuntimeClasspath
-com.squareup.okio:okio:2.9.0=debugRuntimeClasspath, releaseRuntimeClasspath
-org.jetbrains.kotlin:kotlin-stdlib-common:1.4.21=debugRuntimeClasspath, releaseRuntimeClasspath
-org.jetbrains.kotlin:kotlin-stdlib:1.4.21=debugRuntimeClasspath, releaseRuntimeClasspath
-org.jetbrains:annotations:13.0=debugRuntimeClasspath, releaseRuntimeClasspath
+com.squareup.okhttp3:okhttp:5.0.0-alpha.2=debugRuntimeClasspath,releaseRuntimeClasspath
+com.squareup.okio:okio:2.9.0=debugRuntimeClasspath,releaseRuntimeClasspath
+org.jetbrains.kotlin:kotlin-stdlib-common:1.4.21=debugRuntimeClasspath,releaseRuntimeClasspath
+org.jetbrains.kotlin:kotlin-stdlib:1.4.21=debugRuntimeClasspath,releaseRuntimeClasspath
+org.jetbrains:annotations:13.0=debugRuntimeClasspath,releaseRuntimeClasspath
 empty=

--- a/src/test/java/app/cash/better/dynamic/features/BetterDynamicFeaturesPluginTest.kt
+++ b/src/test/java/app/cash/better/dynamic/features/BetterDynamicFeaturesPluginTest.kt
@@ -29,11 +29,40 @@ class BetterDynamicFeaturesPluginTest {
       |# This is a Gradle generated file for dependency locking.
       |# Manual edits can break the build and are not advised.
       |# This file is expected to be part of source control.
-      |com.squareup.okhttp3:okhttp:5.0.0-alpha.2=debugRuntimeClasspath, releaseRuntimeClasspath
-      |com.squareup.okio:okio:2.9.0=debugRuntimeClasspath, releaseRuntimeClasspath
-      |org.jetbrains.kotlin:kotlin-stdlib-common:1.4.21=debugRuntimeClasspath, releaseRuntimeClasspath
-      |org.jetbrains.kotlin:kotlin-stdlib:1.4.21=debugRuntimeClasspath, releaseRuntimeClasspath
-      |org.jetbrains:annotations:13.0=debugRuntimeClasspath, releaseRuntimeClasspath
+      |com.squareup.okhttp3:okhttp:5.0.0-alpha.2=debugRuntimeClasspath,releaseRuntimeClasspath
+      |com.squareup.okio:okio:2.9.0=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains.kotlin:kotlin-stdlib-common:1.4.21=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains.kotlin:kotlin-stdlib:1.4.21=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains:annotations:13.0=debugRuntimeClasspath,releaseRuntimeClasspath
+      |empty=
+      """.trimMargin(),
+    )
+  }
+
+  @Test fun `base configurations have different dependency versions`() {
+    val integrationRoot = File("src/test/fixtures/different-versions-in-base")
+    val baseProject = integrationRoot.resolve("base")
+    clearLockfile(baseProject)
+
+    val gradleRunner = GradleRunner.create()
+      .withCommonConfiguration(integrationRoot)
+      .withArguments("clean", ":base:writeLockfile")
+
+    // Generate lockfile first, and then run dependencies task
+    gradleRunner.build()
+    val result = gradleRunner.withArguments(":base:dependencies").build()
+
+    assertThat(result.output).contains("com.squareup.okhttp3:okhttp:4.9.3 -> 5.0.0-alpha.2")
+    assertThat(baseProject.lockfile().readText()).isEqualTo(
+      """
+      |# This is a Gradle generated file for dependency locking.
+      |# Manual edits can break the build and are not advised.
+      |# This file is expected to be part of source control.
+      |com.squareup.okhttp3:okhttp:5.0.0-alpha.2=debugRuntimeClasspath,releaseRuntimeClasspath
+      |com.squareup.okio:okio:2.9.0=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains.kotlin:kotlin-stdlib-common:1.4.21=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains.kotlin:kotlin-stdlib:1.4.21=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains:annotations:13.0=debugRuntimeClasspath,releaseRuntimeClasspath
       |empty=
       """.trimMargin(),
     )
@@ -58,11 +87,11 @@ class BetterDynamicFeaturesPluginTest {
       |# This is a Gradle generated file for dependency locking.
       |# Manual edits can break the build and are not advised.
       |# This file is expected to be part of source control.
-      |com.squareup.okhttp3:okhttp:4.9.3=debugRuntimeClasspath, releaseRuntimeClasspath
-      |com.squareup.okio:okio:2.8.0=debugRuntimeClasspath, releaseRuntimeClasspath
-      |org.jetbrains.kotlin:kotlin-stdlib-common:1.4.10=debugRuntimeClasspath, releaseRuntimeClasspath
-      |org.jetbrains.kotlin:kotlin-stdlib:1.4.10=debugRuntimeClasspath, releaseRuntimeClasspath
-      |org.jetbrains:annotations:13.0=debugRuntimeClasspath, releaseRuntimeClasspath
+      |com.squareup.okhttp3:okhttp:4.9.3=debugRuntimeClasspath,releaseRuntimeClasspath
+      |com.squareup.okio:okio:2.8.0=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains.kotlin:kotlin-stdlib-common:1.4.10=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains.kotlin:kotlin-stdlib:1.4.10=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains:annotations:13.0=debugRuntimeClasspath,releaseRuntimeClasspath
       |empty=
       """.trimMargin(),
     )
@@ -84,11 +113,11 @@ class BetterDynamicFeaturesPluginTest {
       |# This is a Gradle generated file for dependency locking.
       |# Manual edits can break the build and are not advised.
       |# This file is expected to be part of source control.
-      |com.squareup.okhttp3:okhttp:4.9.3=debugRuntimeClasspath, releaseRuntimeClasspath
-      |com.squareup.okio:okio:2.8.0=debugRuntimeClasspath, releaseRuntimeClasspath
-      |org.jetbrains.kotlin:kotlin-stdlib-common:1.4.10=debugRuntimeClasspath, releaseRuntimeClasspath
-      |org.jetbrains.kotlin:kotlin-stdlib:1.4.10=debugRuntimeClasspath, releaseRuntimeClasspath
-      |org.jetbrains:annotations:13.0=debugRuntimeClasspath, releaseRuntimeClasspath
+      |com.squareup.okhttp3:okhttp:4.9.3=debugRuntimeClasspath,releaseRuntimeClasspath
+      |com.squareup.okio:okio:2.8.0=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains.kotlin:kotlin-stdlib-common:1.4.10=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains.kotlin:kotlin-stdlib:1.4.10=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains:annotations:13.0=debugRuntimeClasspath,releaseRuntimeClasspath
       |empty=
       """.trimMargin(),
     )
@@ -108,11 +137,11 @@ class BetterDynamicFeaturesPluginTest {
       |# This is a Gradle generated file for dependency locking.
       |# Manual edits can break the build and are not advised.
       |# This file is expected to be part of source control.
-      |com.squareup.okhttp3:okhttp:5.0.0-alpha.2=debugRuntimeClasspath, releaseRuntimeClasspath
-      |com.squareup.okio:okio:2.9.0=debugRuntimeClasspath, releaseRuntimeClasspath
-      |org.jetbrains.kotlin:kotlin-stdlib-common:1.4.21=debugRuntimeClasspath, releaseRuntimeClasspath
-      |org.jetbrains.kotlin:kotlin-stdlib:1.4.21=debugRuntimeClasspath, releaseRuntimeClasspath
-      |org.jetbrains:annotations:13.0=debugRuntimeClasspath, releaseRuntimeClasspath
+      |com.squareup.okhttp3:okhttp:5.0.0-alpha.2=debugRuntimeClasspath,releaseRuntimeClasspath
+      |com.squareup.okio:okio:2.9.0=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains.kotlin:kotlin-stdlib-common:1.4.21=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains.kotlin:kotlin-stdlib:1.4.21=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains:annotations:13.0=debugRuntimeClasspath,releaseRuntimeClasspath
       |empty=
       """.trimMargin(),
     )
@@ -153,13 +182,13 @@ class BetterDynamicFeaturesPluginTest {
       |# This is a Gradle generated file for dependency locking.
       |# Manual edits can break the build and are not advised.
       |# This file is expected to be part of source control.
-      |com.squareup.okhttp3:okhttp:5.0.0-alpha.2=debugRuntimeClasspath, releaseRuntimeClasspath
-      |com.squareup.okio:okio:2.9.0=debugRuntimeClasspath, releaseRuntimeClasspath
-      |org.jetbrains.kotlin:kotlin-stdlib-common:1.7.20=debugRuntimeClasspath, releaseRuntimeClasspath
-      |org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.20=debugRuntimeClasspath, releaseRuntimeClasspath
-      |org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20=debugRuntimeClasspath, releaseRuntimeClasspath
-      |org.jetbrains.kotlin:kotlin-stdlib:1.7.20=debugRuntimeClasspath, releaseRuntimeClasspath
-      |org.jetbrains:annotations:13.0=debugRuntimeClasspath, releaseRuntimeClasspath
+      |com.squareup.okhttp3:okhttp:5.0.0-alpha.2=debugRuntimeClasspath,releaseRuntimeClasspath
+      |com.squareup.okio:okio:2.9.0=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains.kotlin:kotlin-stdlib-common:1.7.20=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.20=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains.kotlin:kotlin-stdlib:1.7.20=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains:annotations:13.0=debugRuntimeClasspath,releaseRuntimeClasspath
       |empty=
       """.trimMargin(),
     )
@@ -199,13 +228,13 @@ class BetterDynamicFeaturesPluginTest {
       |# Manual edits can break the build and are not advised.
       |# This file is expected to be part of source control.
       |com.jakewharton.picnic:picnic:0.5.0=debugRuntimeClasspath
-      |com.squareup.okhttp3:okhttp:4.9.3=debugRuntimeClasspath, releaseRuntimeClasspath
-      |com.squareup.okio:okio:2.8.0=debugRuntimeClasspath, releaseRuntimeClasspath
-      |org.jetbrains.kotlin:kotlin-stdlib-common:1.4.10=debugRuntimeClasspath, releaseRuntimeClasspath
+      |com.squareup.okhttp3:okhttp:4.9.3=debugRuntimeClasspath,releaseRuntimeClasspath
+      |com.squareup.okio:okio:2.8.0=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains.kotlin:kotlin-stdlib-common:1.4.10=debugRuntimeClasspath,releaseRuntimeClasspath
       |org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.0=debugRuntimeClasspath
       |org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.0=debugRuntimeClasspath
-      |org.jetbrains.kotlin:kotlin-stdlib:1.4.10=debugRuntimeClasspath, releaseRuntimeClasspath
-      |org.jetbrains:annotations:13.0=debugRuntimeClasspath, releaseRuntimeClasspath
+      |org.jetbrains.kotlin:kotlin-stdlib:1.4.10=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains:annotations:13.0=debugRuntimeClasspath,releaseRuntimeClasspath
       |empty=
       """.trimMargin(),
     )
@@ -260,8 +289,8 @@ class BetterDynamicFeaturesPluginTest {
     gradleRunner.build()
 
     val lockfile = baseProject.lockfile().readText()
-    assertThat(lockfile).contains("com.squareup.sqldelight:runtime-jvm:1.5.4=debugRuntimeClasspath, releaseRuntimeClasspath")
-    assertThat(lockfile).contains("com.squareup.sqldelight:runtime:1.5.4=debugRuntimeClasspath, releaseRuntimeClasspath")
+    assertThat(lockfile).contains("com.squareup.sqldelight:runtime-jvm:1.5.4=debugRuntimeClasspath,releaseRuntimeClasspath")
+    assertThat(lockfile).contains("com.squareup.sqldelight:runtime:1.5.4=debugRuntimeClasspath,releaseRuntimeClasspath")
   }
 
   @Test fun `lockfile does not include project dependencies`() {
@@ -277,7 +306,7 @@ class BetterDynamicFeaturesPluginTest {
     gradleRunner.build()
 
     val lockfile = baseProject.lockfile().readText()
-    assertThat(lockfile).doesNotContain("project-dependency:library:unspecified=debugRuntimeClasspath, releaseRuntimeClasspath")
+    assertThat(lockfile).doesNotContain("project-dependency:library:unspecified=debugRuntimeClasspath,releaseRuntimeClasspath")
   }
 
   private fun clearLockfile(root: File) {


### PR DESCRIPTION
* Remove spaces after comma in configuration entries 
* Use regular Set instead of SortedSet for configuration entries 
* Fix merging different versions of a dependency from different configurations in the base module 
* Fix redundant configuration entries in base lockfile being merged in from feature modules 
* Filter out project dependencies using `Project.DEFAULT_VERSION` (see #33)