### PR TITLE
Don't activate locking when running `checkLockfile`

### DIFF
--- a/src/main/kotlin/app/cash/better/dynamic/features/BetterDynamicFeaturesPlugin.kt
+++ b/src/main/kotlin/app/cash/better/dynamic/features/BetterDynamicFeaturesPlugin.kt
@@ -80,7 +80,8 @@ class BetterDynamicFeaturesPlugin : Plugin<Project> {
       // We only want to enforce the lockfile if we aren't explicitly trying to update it
       if (project.gradle.startParameter.taskNames.none {
         it.contains("writeLockfile", ignoreCase = true) ||
-          it.contains("writePartialLockfile", ignoreCase = true)
+          it.contains("writePartialLockfile", ignoreCase = true) ||
+          it.contains("checkLockfile", ignoreCase = true)
       }
       ) {
         project.configurations.named("${variant.name}RuntimeClasspath").configure {


### PR DESCRIPTION
If the dependency state is out of sync with the lockfile, the `checkLockfile` task will fail at the configuration step when gradle tries to validate the dependency graph. This deactivates the lockfile validation when running this task so that it can correctly report lockfile changes by actually running the task.

(See: https://github.com/squareup/cash-mobile-guide/discussions/352#discussioncomment-4767971)