### PR TITLE
Fix style matching regex for single-line entries

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=app.cash.better.dynamic.features
-VERSION_NAME=0.1.0-alpha13
+VERSION_NAME=0.1.0-alpha14
 
 POM_URL=https://github.com/cashapp/better-dynamic-features/
 POM_SCM_URL=https://github.com/cashapp/better-dynamic-features/

--- a/src/main/kotlin/app/cash/better/dynamic/features/tasks/CheckExternalResourcesTask.kt
+++ b/src/main/kotlin/app/cash/better/dynamic/features/tasks/CheckExternalResourcesTask.kt
@@ -52,8 +52,7 @@ abstract class CheckExternalResourcesTask : DefaultTask() {
     val manifestContents = manifestFile.get().asFile.readText()
 
     // Parsing XML? Haha. No.
-    val stylePattern = Regex("""@(android:)?style\/(.*)+(?=")""")
-    val styleMatches = stylePattern.findAll(manifestContents)
+    val styleMatches = STYLE_PATTERN.findAll(manifestContents)
 
     val resourceModules = incomingResources.artifactFiles.files
       .map { file ->
@@ -153,4 +152,8 @@ abstract class CheckExternalResourcesTask : DefaultTask() {
     ref.replace(Regex("""@(android:)?style\/"""), "").replace(".", "_")
 
   private data class ResourceModule(val namespace: String, val resources: Map<String, Set<String>>)
+
+  companion object {
+    val STYLE_PATTERN = Regex("""@(android:)?style\/.+?(?=")""")
+  }
 }

--- a/src/test/java/app/cash/better/dynamic/features/ResourceScanningTests.kt
+++ b/src/test/java/app/cash/better/dynamic/features/ResourceScanningTests.kt
@@ -1,6 +1,7 @@
 // Copyright Square, Inc.
 package app.cash.better.dynamic.features
 
+import app.cash.better.dynamic.features.tasks.CheckExternalResourcesTask
 import com.google.common.truth.Truth.assertThat
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
@@ -8,6 +9,18 @@ import org.junit.Test
 import java.io.File
 
 class ResourceScanningTests {
+
+  @Test fun `style pattern regex matches xml correctly`() {
+    val fakeXml = """
+      <activity android:name="MyActivity" android:theme="@style/MyActivityTheme" />
+      <activity android:theme"@style/MyOtherTheme" android:name="WoahItInRevere" />
+    """.trimIndent()
+
+    val matches = CheckExternalResourcesTask.STYLE_PATTERN.findAll(fakeXml).map { it.value }.toList()
+    assertThat(matches).contains("@style/MyActivityTheme")
+    assertThat(matches).contains("@style/MyOtherTheme")
+  }
+
   @Test fun `theme defined in dynamic feature and declared as external succeeds`() {
     val integrationRoot = File("src/test/fixtures/resources-correct-declaration")
 


### PR DESCRIPTION
On some builds, AGP will rewrite manifest tags into a single line. The regex I was using to extract `@style` strings was incorrect and would match everything in the tag up until the last `"` character in the entry.