### PR TITLE
Error when updating lockfile with other tasks

### DIFF
--- a/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/BetterDynamicFeaturesPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/BetterDynamicFeaturesPlugin.kt
@@ -29,6 +29,10 @@ class BetterDynamicFeaturesPlugin : Plugin<Project> {
       "Plugin 'com.android.application' or 'com.android.dynamic-feature' must also be applied before this plugin"
     }
 
+    val hasLockfileStartTask = project.gradle.startParameter.taskNames.any { it.contains("writeLockfile", ignoreCase = true) || it.contains(WRITE_DEPENDENCY_GRAPH_REGEX) }
+    val startTaskCount = project.gradle.startParameter.taskNames.count()
+    require(!hasLockfileStartTask || startTaskCount == 1) { "Updating the lockfile and running other tasks together is an error. Update the lockfile first, and then run your other tasks separately." }
+
     if (project.plugins.hasPlugin("com.android.application")) {
       applyToApplication(project)
     } else {
@@ -60,7 +64,7 @@ class BetterDynamicFeaturesPlugin : Plugin<Project> {
       // We only want to enforce the lockfile if we aren't explicitly trying to update it
       if (project.gradle.startParameter.taskNames.none {
         it.contains("writeLockfile", ignoreCase = true) ||
-          it.contains("writePartialLockfile", ignoreCase = true) ||
+          it.contains(WRITE_DEPENDENCY_GRAPH_REGEX) ||
           it.contains("checkLockfile", ignoreCase = true)
       }
       ) {
@@ -238,5 +242,7 @@ class BetterDynamicFeaturesPlugin : Plugin<Project> {
     private const val ARTIFACT_TYPE_BASE_DEPENDENCY_GRAPH = "base-dependency-graph"
 
     private const val VARIANT_DEPENDENCY_GRAPHS = "dependency-graphs"
+
+    private val WRITE_DEPENDENCY_GRAPH_REGEX = Regex("write(.+)DependencyGraph", RegexOption.IGNORE_CASE)
   }
 }

--- a/gradle-plugin/src/test/java/app/cash/better/dynamic/features/BetterDynamicFeaturesPluginTest.kt
+++ b/gradle-plugin/src/test/java/app/cash/better/dynamic/features/BetterDynamicFeaturesPluginTest.kt
@@ -17,7 +17,8 @@ class BetterDynamicFeaturesPluginTest {
 
     val gradleRunner = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
-      .withArguments("clean", ":base:writeLockfile")
+      .cleaned()
+      .withArguments(":base:writeLockfile")
 
     // Generate lockfile first, and then run dependencies task
     gradleRunner.build()
@@ -46,7 +47,8 @@ class BetterDynamicFeaturesPluginTest {
 
     val gradleRunner = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
-      .withArguments("clean", ":base:writeLockfile")
+      .cleaned()
+      .withArguments(":base:writeLockfile")
 
     // Generate lockfile first, and then run dependencies task
     gradleRunner.build()
@@ -75,7 +77,8 @@ class BetterDynamicFeaturesPluginTest {
 
     val gradleRunner = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
-      .withArguments("clean", ":base:writeLockfile")
+      .cleaned()
+      .withArguments(":base:writeLockfile")
 
     // Generate lockfile first, and then run dependencies task
     gradleRunner.build()
@@ -104,7 +107,8 @@ class BetterDynamicFeaturesPluginTest {
 
     val result = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
-      .withArguments("clean", ":base:writeLockfile")
+      .cleaned()
+      .withArguments(":base:writeLockfile")
       .build()
 
     assertThat(result.output).contains("BUILD SUCCESSFUL")
@@ -155,7 +159,8 @@ class BetterDynamicFeaturesPluginTest {
 
     val gradleRunner = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
-      .withArguments("clean", ":base:writeLockfile")
+      .cleaned()
+      .withArguments(":base:writeLockfile")
 
     val result = gradleRunner.build()
     assertThat(result.output).contains("BUILD SUCCESSFUL")
@@ -170,7 +175,8 @@ class BetterDynamicFeaturesPluginTest {
 
     val gradleRunner = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
-      .withArguments("clean", ":base:writeLockfile")
+      .cleaned()
+      .withArguments(":base:writeLockfile")
 
     // Generate lockfile first, and then run dependencies task
     gradleRunner.build()
@@ -202,7 +208,8 @@ class BetterDynamicFeaturesPluginTest {
 
     val gradleRunner = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
-      .withArguments("clean", ":base:writeLockfile")
+      .cleaned()
+      .withArguments(":base:writeLockfile")
 
     // Generate lockfile first, and then run dependencies task
     gradleRunner.build()
@@ -234,7 +241,8 @@ class BetterDynamicFeaturesPluginTest {
 
     val gradleRunner = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
-      .withArguments("clean", ":base:writeLockfile")
+      .cleaned()
+      .withArguments(":base:writeLockfile")
 
     // Generate lockfile first, and then run dependencies task
     gradleRunner.build()
@@ -261,7 +269,8 @@ class BetterDynamicFeaturesPluginTest {
 
     val gradleRunner = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
-      .withArguments("clean", ":base:build")
+      .cleaned()
+      .withArguments(":base:build")
 
     val result = gradleRunner.buildAndFail()
 
@@ -277,7 +286,8 @@ class BetterDynamicFeaturesPluginTest {
 
     val gradleRunner = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
-      .withArguments("clean", ":base:writeLockfile")
+      .cleaned()
+      .withArguments(":base:writeLockfile")
 
     // Generate lockfile first, and then run dependencies task
     gradleRunner.build()
@@ -313,7 +323,8 @@ class BetterDynamicFeaturesPluginTest {
 
     val gradleRunner = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
-      .withArguments("clean", ":base:installDebug")
+      .cleaned()
+      .withArguments(":base:installDebug")
 
     val result = gradleRunner.buildAndFail()
     assertThat(result.output).contains("The lockfile was out of date and has been updated. Rerun your build.")
@@ -328,7 +339,8 @@ class BetterDynamicFeaturesPluginTest {
 
     val gradleRunner = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
-      .withArguments("clean", ":base:preBuild")
+      .cleaned()
+      .withArguments(":base:preBuild")
 
     gradleRunner.build()
 
@@ -345,8 +357,8 @@ class BetterDynamicFeaturesPluginTest {
 
     val gradleRunner = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
-      .withDebug(true)
-      .withArguments("clean", ":base:writeLockfile")
+      .cleaned()
+      .withArguments(":base:writeLockfile")
 
     gradleRunner.build()
 
@@ -362,8 +374,8 @@ class BetterDynamicFeaturesPluginTest {
 
     val gradleRunner = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
-      .withDebug(true)
-      .withArguments("clean", ":base:writeLockfile")
+      .cleaned()
+      .withArguments(":base:writeLockfile")
 
     gradleRunner.build()
 
@@ -379,7 +391,8 @@ class BetterDynamicFeaturesPluginTest {
 
     val gradleRunner = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
-      .withArguments("clean", ":base:writeLockfile")
+      .cleaned()
+      .withArguments(":base:writeLockfile")
 
     // Generate lockfile first, and then run dependencies task
     gradleRunner.build()
@@ -408,7 +421,8 @@ class BetterDynamicFeaturesPluginTest {
 
     val gradleRunner = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
-      .withArguments("clean", ":base:writeLockfile")
+      .cleaned()
+      .withArguments(":base:writeLockfile")
 
     // Generate lockfile first, and then run dependencies task
     gradleRunner.build()
@@ -467,9 +481,23 @@ class BetterDynamicFeaturesPluginTest {
     // This tests that the :feature module is configured indirectly through being depended on by :base
     val gradleRunner = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
-      .withArguments("-Dorg.gradle.configureondemand=true", ":base:clean", ":base:writeLockfile")
+      .cleaned(module = "base")
+      .withArguments("-Dorg.gradle.configureondemand=true", ":base:writeLockfile")
 
     gradleRunner.build()
+  }
+
+  @Test fun `updating lockfile while with other tasks fails`() {
+    val integrationRoot = File("src/test/fixtures/same-versions")
+    val baseProject = integrationRoot.resolve("base")
+    clearLockfile(baseProject)
+
+    val gradleRunner = GradleRunner.create()
+      .withCommonConfiguration(integrationRoot)
+      .withArguments("clean", ":base:writeLockfile")
+
+    val result = gradleRunner.buildAndFail()
+    assertThat(result.output).contains("Updating the lockfile and running other tasks together is an error. Update the lockfile first, and then run your other tasks separately.")
   }
 
   private fun clearLockfile(root: File) {

--- a/gradle-plugin/src/test/java/app/cash/better/dynamic/features/ResourceScanningTests.kt
+++ b/gradle-plugin/src/test/java/app/cash/better/dynamic/features/ResourceScanningTests.kt
@@ -26,10 +26,12 @@ class ResourceScanningTests {
 
     val gradleRunner = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
-      .withArguments("clean", "base:writeLockfile", ":base:assembleDebug")
+      .withFreshLockfile()
+      .withArguments("clean", ":base:assembleDebug")
 
     val result = gradleRunner.build()
     assertThat(result.output).contains("BUILD SUCCESSFUL")
+    println(result.output)
     assertThat(result.task(":base:generateDebugExternalResources")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
     assertThat(result.task(":base:checkDebugExternalResources")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
   }
@@ -39,7 +41,8 @@ class ResourceScanningTests {
 
     val gradleRunner = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
-      .withArguments("clean", "base:writeLockfile", ":base:assembleDebug")
+      .withFreshLockfile()
+      .withArguments("clean", ":base:assembleDebug")
 
     val result = gradleRunner.buildAndFail()
     assertThat(result.output).contains("Some resources are defined externally but not declared as external.")
@@ -60,7 +63,8 @@ class ResourceScanningTests {
 
     val gradleRunner = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
-      .withArguments("clean", "base:writeLockfile", ":base:assembleDebug")
+      .withFreshLockfile()
+      .withArguments("clean", ":base:assembleDebug")
 
     val result = gradleRunner.buildAndFail()
     assertThat(result.output).contains("Some external resource declarations are overwriting actual resource definitions.")
@@ -73,7 +77,8 @@ class ResourceScanningTests {
 
     val gradleRunner = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
-      .withArguments("clean", "base:writeLockfile", ":base:assembleDebug")
+      .withFreshLockfile()
+      .withArguments("clean", ":base:assembleDebug")
 
     val result = gradleRunner.build()
     assertThat(result.output).contains("BUILD SUCCESSFUL")
@@ -86,7 +91,8 @@ class ResourceScanningTests {
 
     val gradleRunner = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
-      .withArguments("clean", "base:writeLockfile", ":base:assembleDebug")
+      .withFreshLockfile()
+      .withArguments("clean", ":base:assembleDebug")
 
     val result = gradleRunner.build()
     println(result.output)

--- a/gradle-plugin/src/test/java/app/cash/better/dynamic/features/TestUtils.kt
+++ b/gradle-plugin/src/test/java/app/cash/better/dynamic/features/TestUtils.kt
@@ -40,3 +40,13 @@ internal fun androidHome(): String {
 }
 
 internal fun String.withInvariantPathSeparators() = replace("\\", "/")
+
+fun GradleRunner.withFreshLockfile(module: String = "base"): GradleRunner {
+  withArguments("$module:writeLockfile").build()
+  return this
+}
+
+fun GradleRunner.cleaned(module: String? = null): GradleRunner {
+  withArguments(if (module == null) "clean" else "$module:clean").build()
+  return this
+}


### PR DESCRIPTION
This change adds a new restriction so that the `writeLockfile` task can be the _only_ task requested in a single gradle command to address an "implicit dependency" warning/soon-to-be-error, and avoid potential inconsistent locking state issues.

i.e.
```shell
# OK
./gradlew writeLockfile

# Not OK
./gradlew writeLockfile build
```

This fixes an implicit dependency issue (which will become an error in Gradle 8) caused by running `writeLockfile` and then another task that triggers `checkLockfile` to be run. Technically `writeLockfile` produces a file that is consumed by `checkLockfile` and there is no explicit dependency configured, and there shouldn't be. By enforcing that the `writeLockfile` task must be run separately, we avoid an accidental implicit dependency between those tasks. 

In order to update the lockfile with the `writeLockfile` task we have to disable the actual dependency locking. This is because if the lockfile is out of sync, the `writeLockfile` task itself can fail to configure if it resolves dependencies that are inconsistent with Gradle's dependency locking state. (We would have to somehow hook into Gradle's dependency locking internals to avoid this). Because we disable the dependency locking when configuring for the `writeLockfile` task, if other tasks are requested in the same gradle command, those tasks could erroneously succeed despite the lockfile state being incorrect. 
