### PR TITLE
Rework the configuration of the resource tasks

### DIFF
--- a/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/BetterDynamicFeaturesFeatureExtension.kt
+++ b/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/BetterDynamicFeaturesFeatureExtension.kt
@@ -1,0 +1,9 @@
+// Copyright Square, Inc.
+package app.cash.better.dynamic.features
+
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
+
+abstract class BetterDynamicFeaturesFeatureExtension {
+  abstract val baseProject: Property<Project>
+}

--- a/gradle-plugin/src/test/fixtures/attr-rewrite-binary/feature/build.gradle.kts
+++ b/gradle-plugin/src/test/fixtures/attr-rewrite-binary/feature/build.gradle.kts
@@ -33,6 +33,10 @@ android {
   }
 }
 
+betterDynamicFeatures {
+  baseProject.set(project(":app"))
+}
+
 dependencies {
   implementation(project(":app"))
 

--- a/gradle-plugin/src/test/fixtures/custom-lockfile/feature/build.gradle
+++ b/gradle-plugin/src/test/fixtures/custom-lockfile/feature/build.gradle
@@ -11,3 +11,7 @@ dependencies {
   implementation project(":base")
   implementation "com.squareup.okhttp3:okhttp:4.9.3"
 }
+
+betterDynamicFeatures {
+  baseProject.set(project(":base"))
+}

--- a/gradle-plugin/src/test/fixtures/different-versions-in-base/feature/build.gradle
+++ b/gradle-plugin/src/test/fixtures/different-versions-in-base/feature/build.gradle
@@ -10,3 +10,7 @@ android {
 dependencies {
   implementation project(":base")
 }
+
+betterDynamicFeatures {
+  baseProject.set(project(":base"))
+}

--- a/gradle-plugin/src/test/fixtures/different-versions/feature/build.gradle
+++ b/gradle-plugin/src/test/fixtures/different-versions/feature/build.gradle
@@ -11,3 +11,7 @@ dependencies {
   implementation project(":base")
   implementation "com.squareup.okhttp3:okhttp:5.0.0-alpha.2"
 }
+
+betterDynamicFeatures {
+  baseProject.set(project(":base"))
+}

--- a/gradle-plugin/src/test/fixtures/lockfile-activation/feature/build.gradle
+++ b/gradle-plugin/src/test/fixtures/lockfile-activation/feature/build.gradle
@@ -11,3 +11,7 @@ dependencies {
   implementation project(":base")
   implementation "com.squareup.okhttp3:okhttp:4.9.3"
 }
+
+betterDynamicFeatures {
+  baseProject.set(project(":base"))
+}

--- a/gradle-plugin/src/test/fixtures/multiplatform-dependency/feature/build.gradle
+++ b/gradle-plugin/src/test/fixtures/multiplatform-dependency/feature/build.gradle
@@ -11,3 +11,7 @@ dependencies {
   implementation project(":base")
   implementation "com.squareup.sqldelight:runtime:1.5.4"
 }
+
+betterDynamicFeatures {
+  baseProject.set(project(":base"))
+}

--- a/gradle-plugin/src/test/fixtures/new-transitive-dependency/feature/build.gradle
+++ b/gradle-plugin/src/test/fixtures/new-transitive-dependency/feature/build.gradle
@@ -11,3 +11,7 @@ dependencies {
   implementation project(":base")
   implementation "com.google.android.material:material:1.7.0"
 }
+
+betterDynamicFeatures {
+  baseProject.set(project(":base"))
+}

--- a/gradle-plugin/src/test/fixtures/out-of-date/feature/build.gradle
+++ b/gradle-plugin/src/test/fixtures/out-of-date/feature/build.gradle
@@ -11,3 +11,7 @@ dependencies {
   implementation project(":base")
   implementation "com.squareup.okhttp3:okhttp:5.0.0-alpha.2"
 }
+
+betterDynamicFeatures {
+  baseProject.set(project(":base"))
+}

--- a/gradle-plugin/src/test/fixtures/project-dependency/feature/build.gradle
+++ b/gradle-plugin/src/test/fixtures/project-dependency/feature/build.gradle
@@ -12,3 +12,7 @@ dependencies {
   implementation project(":base")
   implementation "com.squareup.okhttp3:okhttp:4.9.3"
 }
+
+betterDynamicFeatures {
+  baseProject.set(project(":base"))
+}

--- a/gradle-plugin/src/test/fixtures/resources-correct-declaration/feature/build.gradle
+++ b/gradle-plugin/src/test/fixtures/resources-correct-declaration/feature/build.gradle
@@ -12,3 +12,7 @@ dependencies {
   implementation project(":base")
   implementation "com.squareup.okhttp3:okhttp:4.9.3"
 }
+
+betterDynamicFeatures {
+  baseProject.set(project(":base"))
+}

--- a/gradle-plugin/src/test/fixtures/resources-in-base/feature/build.gradle
+++ b/gradle-plugin/src/test/fixtures/resources-in-base/feature/build.gradle
@@ -12,3 +12,7 @@ dependencies {
   implementation project(":base")
   implementation "com.squareup.okhttp3:okhttp:4.9.3"
 }
+
+betterDynamicFeatures {
+  baseProject.set(project(":base"))
+}

--- a/gradle-plugin/src/test/fixtures/resources-missing-declaration/feature/build.gradle
+++ b/gradle-plugin/src/test/fixtures/resources-missing-declaration/feature/build.gradle
@@ -12,3 +12,7 @@ dependencies {
   implementation project(":base")
   implementation "com.squareup.okhttp3:okhttp:4.9.3"
 }
+
+betterDynamicFeatures {
+  baseProject.set(project(":base"))
+}

--- a/gradle-plugin/src/test/fixtures/resources-normal/feature/build.gradle
+++ b/gradle-plugin/src/test/fixtures/resources-normal/feature/build.gradle
@@ -13,3 +13,7 @@ dependencies {
   implementation project(":library")
   implementation "com.squareup.okhttp3:okhttp:4.9.3"
 }
+
+betterDynamicFeatures {
+  baseProject.set(project(":base"))
+}

--- a/gradle-plugin/src/test/fixtures/resources-overwriting/feature/build.gradle
+++ b/gradle-plugin/src/test/fixtures/resources-overwriting/feature/build.gradle
@@ -13,3 +13,7 @@ dependencies {
   implementation project(":library")
   implementation "com.squareup.okhttp3:okhttp:4.9.3"
 }
+
+betterDynamicFeatures {
+  baseProject.set(project(":base"))
+}

--- a/gradle-plugin/src/test/fixtures/same-versions/feature/build.gradle
+++ b/gradle-plugin/src/test/fixtures/same-versions/feature/build.gradle
@@ -11,3 +11,7 @@ dependencies {
   implementation project(":base")
   implementation "com.squareup.okhttp3:okhttp:4.9.3"
 }
+
+betterDynamicFeatures {
+  baseProject.set(project(":base"))
+}

--- a/gradle-plugin/src/test/fixtures/transitive-dependency-on-base-variant-aware/feature/build.gradle
+++ b/gradle-plugin/src/test/fixtures/transitive-dependency-on-base-variant-aware/feature/build.gradle
@@ -12,3 +12,7 @@ dependencies {
   implementation project(":base")
   implementation "com.squareup.okhttp3:okhttp:4.9.3"
 }
+
+betterDynamicFeatures {
+  baseProject.set(project(":base"))
+}

--- a/gradle-plugin/src/test/fixtures/transitive-dependency-on-base/feature/build.gradle
+++ b/gradle-plugin/src/test/fixtures/transitive-dependency-on-base/feature/build.gradle
@@ -12,3 +12,7 @@ dependencies {
   implementation project(":base")
   implementation "com.squareup.okhttp3:okhttp:4.9.3"
 }
+
+betterDynamicFeatures {
+  baseProject.set(project(":base"))
+}

--- a/gradle-plugin/src/test/fixtures/transitive-dependency/feature/build.gradle
+++ b/gradle-plugin/src/test/fixtures/transitive-dependency/feature/build.gradle
@@ -13,3 +13,7 @@ dependencies {
   implementation "com.squareup.okhttp3:okhttp:4.9.3"
   implementation project(":library")
 }
+
+betterDynamicFeatures {
+  baseProject.set(project(":base"))
+}

--- a/gradle-plugin/src/test/fixtures/up-to-date/feature/build.gradle
+++ b/gradle-plugin/src/test/fixtures/up-to-date/feature/build.gradle
@@ -11,3 +11,7 @@ dependencies {
   implementation project(":base")
   implementation "com.squareup.okhttp3:okhttp:5.0.0-alpha.2"
 }
+
+betterDynamicFeatures {
+  baseProject.set(project(":base"))
+}

--- a/gradle-plugin/src/test/fixtures/variant-aware/feature/build.gradle
+++ b/gradle-plugin/src/test/fixtures/variant-aware/feature/build.gradle
@@ -12,3 +12,7 @@ dependencies {
   implementation "com.squareup.okhttp3:okhttp:4.9.3"
   debugImplementation "com.jakewharton.picnic:picnic:0.5.0"
 }
+
+betterDynamicFeatures {
+  baseProject.set(project(":base"))
+}

--- a/gradle-plugin/src/test/fixtures/version-update/feature/build.gradle
+++ b/gradle-plugin/src/test/fixtures/version-update/feature/build.gradle
@@ -11,3 +11,7 @@ dependencies {
   implementation project(":base")
   implementation "com.squareup.okhttp3:okhttp:4.9.3"
 }
+
+betterDynamicFeatures {
+  baseProject.set(project(":base"))
+}


### PR DESCRIPTION
Trying to extract the "base" module from the feature module's dependencies is flaky, so this change allows the base module to be specified explicitly.

Also removes delegated properties from the resource rewriting task