### PR TITLE
Fix config caching of check external resources task

### DIFF
--- a/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/BetterDynamicFeaturesPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/BetterDynamicFeaturesPlugin.kt
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.Usage
+import org.gradle.api.file.Directory
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.configurationcache.extensions.capitalized
 
@@ -266,7 +267,7 @@ class BetterDynamicFeaturesPlugin : Plugin<Project> {
         task.manifestFile.set(variant.artifacts.get(SingleArtifact.MERGED_MANIFEST))
         task.externalDeclarations.set(provider { pluginExtension.externalStyles })
         task.result.set(project.layout.buildDirectory.file("betterDynamicFeatures/resourcesCheck/${variant.name}/result.txt"))
-        variant.sources.res?.all?.let { task.localResources.set(it) }
+        variant.sources.res?.all?.let { task.localResources.setFrom(it.map(List<Collection<Directory>>::flatten)) }
 
         task.group = GROUP
       }

--- a/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/tasks/CheckExternalResourcesTask.kt
+++ b/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/tasks/CheckExternalResourcesTask.kt
@@ -5,7 +5,6 @@ import app.cash.better.dynamic.features.BetterDynamicFeaturesExtension
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.ArtifactCollection
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.Directory
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Provider
@@ -43,9 +42,9 @@ abstract class CheckExternalResourcesTask : DefaultTask() {
   @get:Input
   abstract val externalDeclarations: ListProperty<String>
 
-  @get:Input
+  @get:InputFiles
   @get:Optional
-  abstract val localResources: ListProperty<Collection<Directory>>
+  abstract val localResources: ConfigurableFileCollection
 
   @get:OutputFile
   abstract val result: RegularFileProperty
@@ -132,10 +131,7 @@ abstract class CheckExternalResourcesTask : DefaultTask() {
   }
 
   private fun computeLocalResources(): ResourceModule? {
-    val localResources = localResources?.get() ?: return null
-
-    val localStyles = localResources.flatten()
-      .map { it.asFile }
+    val localStyles = localResources.files
       .filter {
         // Exclude the resources we generate
         "ExternalResources" !in it.path && it.exists()


### PR DESCRIPTION
Adds an output property to `CheckExternalResourcesTask` to enable configuration caching.

Fixes #55 