### PR TITLE
Fix configuration cache compat in dep graph task

### DIFF
--- a/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/tasks/DependencyGraphConsumingTask.kt
+++ b/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/tasks/DependencyGraphConsumingTask.kt
@@ -9,6 +9,7 @@ import org.gradle.api.tasks.Internal
 abstract class DependencyGraphConsumingTask : DefaultTask() {
   @field:Internal
   private val moshi = Moshi.Builder().build()
+
   @field:Internal
   private val adapter = moshi.adapter(NodeList::class.java)
 


### PR DESCRIPTION
For some reason Gradle was trying to serialize/deserialize these private fields