### PR TITLE
Set up a toolchain convention plugin

### DIFF
--- a/buildLogic/convention/build.gradle
+++ b/buildLogic/convention/build.gradle
@@ -1,0 +1,17 @@
+plugins {
+  alias(libs.plugins.kotlin)
+  id("java-gradle-plugin")
+}
+
+gradlePlugin {
+  plugins {
+    convention {
+      id = "app.cash.better-dynamic-features.convention"
+      implementationClass = "app.cash.better.dynamic.features.Convention"
+    }
+  }
+}
+
+dependencies {
+  compileOnly(libs.kotlin)
+}

--- a/buildLogic/convention/src/main/kotlin/app/cash/better/dynamic/features/Convention.kt
+++ b/buildLogic/convention/src/main/kotlin/app/cash/better/dynamic/features/Convention.kt
@@ -1,0 +1,38 @@
+package app.cash.better.dynamic.features
+
+import org.gradle.api.JavaVersion
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JvmVendorSpec
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+class Convention : Plugin<Project> {
+  override fun apply(target: Project) {
+    target.plugins.apply("org.jetbrains.kotlin.jvm")
+
+    target.kotlinExtension.jvmToolchain { spec ->
+      spec.languageVersion.set(JavaLanguageVersion.of(TOOLCHAIN_JDK))
+      spec.vendor.set(JvmVendorSpec.AZUL)
+    }
+
+    target.tasks.withType(KotlinCompile::class.java).configureEach { task ->
+      task.compilerOptions {
+        jvmTarget.set(JvmTarget.fromTarget(TARGET_JDK.toString()))
+      }
+    }
+
+    target.extensions.findByType(JavaPluginExtension::class.java)?.apply {
+      sourceCompatibility = JavaVersion.toVersion(TARGET_JDK)
+      targetCompatibility = JavaVersion.toVersion(TARGET_JDK)
+    }
+  }
+
+  private companion object {
+    const val TOOLCHAIN_JDK = 17
+    const val TARGET_JDK = 11
+  }
+}

--- a/buildLogic/settings.gradle
+++ b/buildLogic/settings.gradle
@@ -1,0 +1,16 @@
+dependencyResolutionManagement {
+  repositories {
+    mavenCentral()
+    google()
+  }
+
+  versionCatalogs {
+    libs {
+      from(files("../gradle/libs.versions.toml"))
+    }
+  }
+}
+
+rootProject.name = "buildLogic"
+
+include(":convention")

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -1,9 +1,8 @@
 import com.google.devtools.ksp.gradle.KspTaskJvm
 import com.squareup.wire.gradle.WireTask
 
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-  alias(libs.plugins.kotlin)
+  id("app.cash.better-dynamic-features.convention")
   alias(libs.plugins.ksp)
   id("java-gradle-plugin")
   alias(libs.plugins.publish)

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,11 @@ pluginManagement {
     gradlePluginPortal()
   }
 }
+
+plugins {
+  id "org.gradle.toolchains.foojay-resolver-convention" version "0.5.0"
+}
+
 dependencyResolutionManagement {
   repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
   repositories {
@@ -14,5 +19,7 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "better-dynamic-features"
+
+includeBuild("buildLogic")
 
 include(":gradle-plugin")


### PR DESCRIPTION
This will help smooth over the transition to AGP 8 and the JDK 17 requirement (especially as we add new modules).