### PR TITLE
Add an AGP version compatibility check

### DIFF
--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -1,5 +1,6 @@
 import com.google.devtools.ksp.gradle.KspTaskJvm
 import com.squareup.wire.gradle.WireTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   id("app.cash.better-dynamic-features.convention")
@@ -17,6 +18,10 @@ gradlePlugin {
       implementationClass = 'app.cash.better.dynamic.features.BetterDynamicFeaturesPlugin'
     }
   }
+}
+
+sourceSets {
+  main.kotlin.srcDir "$buildDir/gen"
 }
 
 dependencies {
@@ -60,6 +65,26 @@ publishing {
     }
   }
 }
+
+def pluginVersion = tasks.register("pluginVersion") {
+  def outputDir = file("$buildDir/gen")
+
+  inputs.property 'version', version
+  outputs.dir outputDir
+
+  doLast {
+    def versionFile = file("$outputDir/app/cash/better/dynamic/features/Version.kt")
+    versionFile.parentFile.mkdirs()
+    versionFile.text = """// Generated file. Do not edit!
+package app.cash.better.dynamic.features
+
+val TARGET_AGP_VERSION = "${libs.versions.agp.get()}"
+"""
+  }
+}
+
+tasks.withType(KotlinCompile).configureEach { dependsOn(pluginVersion) }
+tasks.withType(KspTaskJvm).configureEach { dependsOn(pluginVersion) }
 
 wire {
   kotlin {}

--- a/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/BetterDynamicFeaturesPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/BetterDynamicFeaturesPlugin.kt
@@ -11,6 +11,7 @@ import app.cash.better.dynamic.features.tasks.CheckExternalResourcesTask
 import app.cash.better.dynamic.features.tasks.CheckLockfileTask
 import app.cash.better.dynamic.features.tasks.DependencyGraphWriterTask
 import app.cash.better.dynamic.features.tasks.GenerateExternalResourcesTask
+import com.android.Version
 import com.android.build.api.artifact.SingleArtifact
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.variant.AndroidComponentsExtension
@@ -34,6 +35,11 @@ class BetterDynamicFeaturesPlugin : Plugin<Project> {
   override fun apply(project: Project) {
     check(project.plugins.hasPlugin("com.android.application") || project.plugins.hasPlugin("com.android.dynamic-feature")) {
       "Plugin 'com.android.application' or 'com.android.dynamic-feature' must also be applied before this plugin"
+    }
+
+    // Do a strict version check to ensure that our monkey-patching will work correctly.
+    check(Version.ANDROID_GRADLE_PLUGIN_VERSION == TARGET_AGP_VERSION) {
+      "This version of the Android Gradle Plugin (${Version.ANDROID_GRADLE_PLUGIN_VERSION}) is not supported by the better-dynamic-features plugin. Only version $TARGET_AGP_VERSION is supported."
     }
 
     val hasLockfileStartTask = project.gradle.startParameter.taskNames.any {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,11 @@
 [versions]
+agp = "7.4.2"
 kotlin = "1.8.20"
 ktlint = "0.46.1"
 moshi = "1.14.0"
 
 [libraries]
-agp = { module = "com.android.tools.build:gradle", version = "7.4.2" }
+agp = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 javassist = { module = "org.javassist:javassist", version = "3.29.1-GA" }
 kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 moshi-core = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }


### PR DESCRIPTION
The plugin is currently strongly coupled to the build of AGP being used because we're doing some monkey-patching to address some issues. This check ensures that the project is on the correct version.