### PR TITLE
Stream dexdump output in tests

### DIFF
--- a/gradle-plugin/src/test/java/app/cash/better/dynamic/features/ResourceRewriteTests.kt
+++ b/gradle-plugin/src/test/java/app/cash/better/dynamic/features/ResourceRewriteTests.kt
@@ -1,5 +1,6 @@
 package app.cash.better.dynamic.features
 
+import app.cash.better.dynamic.features.utils.assertThat
 import com.google.common.truth.Truth.assertThat
 import com.reandroid.apk.ApkModule
 import org.gradle.testkit.runner.GradleRunner
@@ -145,20 +146,21 @@ class ResourceRewriteTests {
     val apkOutput = integrationRoot.resolve("app/build/outputs/apk_from_bundle/debug/app-debug-universal.apk")
     val dexContent = dexdump(apkOutput)
 
-    assertThat(dexContent.bufferedReader().lineSequence().asIterable())
-      .containsAtLeast(
+    assertThat(dexContent.bufferedReader().lineSequence())
+      .containsInConsecutiveOrder(
         """      name          : 'specialText'""",
         """      type          : 'I'""",
         """      access        : 0x0019 (PUBLIC STATIC FINAL)""",
         """      value         : $mappedAttr""",
-      ).inOrder()
+      )
 
-    assertThat(dexContent.bufferedReader().lineSequence().asIterable()).containsAtLeast(
-      """      name          : 'button_first'""",
-      """      type          : 'I'""",
-      """      access        : 0x0019 (PUBLIC STATIC FINAL)""",
-      """      value         : $mappedId""",
-    ).inOrder()
+    assertThat(dexContent.bufferedReader().lineSequence())
+      .containsInConsecutiveOrder(
+        """      name          : 'button_first'""",
+        """      type          : 'I'""",
+        """      access        : 0x0019 (PUBLIC STATIC FINAL)""",
+        """      value         : $mappedId""",
+      )
   }
 
   @Test

--- a/gradle-plugin/src/test/java/app/cash/better/dynamic/features/utils/SequenceSubject.kt
+++ b/gradle-plugin/src/test/java/app/cash/better/dynamic/features/utils/SequenceSubject.kt
@@ -1,0 +1,43 @@
+package app.cash.better.dynamic.features.utils
+
+import com.google.common.truth.Fact.simpleFact
+import com.google.common.truth.FailureMetadata
+import com.google.common.truth.Subject
+import com.google.common.truth.Subject.Factory
+import com.google.common.truth.Truth.assertAbout
+
+class SequenceSubject<T>(metadata: FailureMetadata, private val actual: Sequence<T>) :
+  Subject(metadata, actual) {
+  fun containsInConsecutiveOrder(vararg values: T) {
+    var matchCounter = 0
+    actual.forEach {
+      if (matchCounter == values.size) return@forEach
+      if (it == values[matchCounter]) {
+        matchCounter++
+      } else {
+        matchCounter = 0
+      }
+    }
+
+    if (matchCounter != values.size) {
+      failWithoutActual(
+        simpleFact(
+          "Expected to find ${
+          values.joinToString(
+            prefix = "[",
+            postfix = "]",
+          )
+          } in consecutive order, but they were not found.",
+        ),
+      )
+    }
+  }
+
+  companion object {
+    @JvmStatic
+    fun <T> sequences(): Factory<SequenceSubject<T>, Sequence<T>> = Factory(::SequenceSubject)
+  }
+}
+
+fun <T> assertThat(actual: Sequence<T>): SequenceSubject<T> =
+  assertAbout(SequenceSubject.sequences<T>()).that(actual)


### PR DESCRIPTION
Addresses a common OOM error in tests since the dexdump output of a full APK can be quite large and it was being read entirely into memory.

This fixes the failing test in #65 