### PR TITLE
Fix transitive dependency handling in lockfiles

### DIFF
--- a/gradle-plugin/src/test/java/app/cash/better/dynamic/features/BetterDynamicFeaturesPluginTest.kt
+++ b/gradle-plugin/src/test/java/app/cash/better/dynamic/features/BetterDynamicFeaturesPluginTest.kt
@@ -431,45 +431,10 @@ class BetterDynamicFeaturesPluginTest {
     assertThat(result.output).contains("com.google.android.material:material:1.2.0 -> 1.7.0")
     // Dynamic animation is a new transitive dependency of material added after 1.2.0
     assertThat(result.output).contains("androidx.dynamicanimation:dynamicanimation:1.0.0")
-    assertThat(baseProject.lockfile().readText()).isEqualTo(
-      """
-      |# This is a Gradle generated file for dependency locking.
-      |# Manual edits can break the build and are not advised.
-      |# This file is expected to be part of source control.
-      |androidx.activity:activity:1.5.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.annotation:annotation-experimental:1.1.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.annotation:annotation:1.3.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.appcompat:appcompat-resources:1.5.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.appcompat:appcompat:1.5.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.arch.core:core-common:2.1.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.arch.core:core-runtime:2.1.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.cardview:cardview:1.0.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.collection:collection:1.1.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.coordinatorlayout:coordinatorlayout:1.1.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.core:core:1.8.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.cursoradapter:cursoradapter:1.0.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.customview:customview:1.1.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.drawerlayout:drawerlayout:1.1.1=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.fragment:fragment:1.3.6=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.interpolator:interpolator:1.0.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.lifecycle:lifecycle-common:2.5.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.lifecycle:lifecycle-livedata-core:2.5.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.lifecycle:lifecycle-livedata:2.0.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.lifecycle:lifecycle-runtime:2.5.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.lifecycle:lifecycle-viewmodel:2.5.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.loader:loader:1.0.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.recyclerview:recyclerview:1.1.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.savedstate:savedstate:1.2.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.transition:transition:1.2.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.vectordrawable:vectordrawable-animated:1.1.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.vectordrawable:vectordrawable:1.1.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.versionedparcelable:versionedparcelable:1.1.1=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.viewpager2:viewpager2:1.0.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |androidx.viewpager:viewpager:1.0.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |com.google.android.material:material:1.7.0=debugRuntimeClasspath,releaseRuntimeClasspath
-      |empty=
-      """.trimMargin(),
-    )
+
+    val lockfileContent = baseProject.lockfile().readText()
+    assertThat(lockfileContent).contains("com.google.android.material:material:1.7.0=debugRuntimeClasspath,releaseRuntimeClasspath")
+    assertThat(lockfileContent).contains("androidx.dynamicanimation:dynamicanimation:1.0.0=debugRuntimeClasspath,releaseRuntimeClasspath")
   }
 
   @Test fun `writeLockfile task passes with configureondemand enabled`() {


### PR DESCRIPTION
The test was passing incorrectly. 
This fix now registers transitive dependencies on dependency upgrades correctly. 