### PR TITLE
Handle feature module compile deps separately

### DIFF
--- a/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/tasks/DependencyGraph.kt
+++ b/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/tasks/DependencyGraph.kt
@@ -10,7 +10,13 @@ data class Node(
   val configurations: MutableSet<String>,
   val children: List<Node>,
   val isProjectModule: Boolean,
+  val type: DependencyType,
 )
+
+enum class DependencyType {
+  Runtime,
+  Compile;
+}
 
 @JsonClass(generateAdapter = true)
 data class NodeList(val nodes: List<Node>)

--- a/gradle-plugin/src/test/fixtures/feature-compile-classpath/base/build.gradle
+++ b/gradle-plugin/src/test/fixtures/feature-compile-classpath/base/build.gradle
@@ -1,0 +1,14 @@
+apply plugin: 'com.android.application'
+apply plugin: 'app.cash.better.dynamic.features'
+
+android {
+  namespace "app.cash.better.dynamic.features.integration"
+
+  compileSdk 32
+
+  dynamicFeatures = [':feature']
+}
+
+dependencies {
+  runtimeOnly "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.0"
+}

--- a/gradle-plugin/src/test/fixtures/feature-compile-classpath/build.gradle
+++ b/gradle-plugin/src/test/fixtures/feature-compile-classpath/build.gradle
@@ -1,0 +1,13 @@
+buildscript {
+  apply from: "${projectDir.absolutePath}/../buildscript.gradle"
+}
+
+allprojects {
+  repositories {
+    maven {
+      url "file://${rootDir}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+}

--- a/gradle-plugin/src/test/fixtures/feature-compile-classpath/feature/build.gradle
+++ b/gradle-plugin/src/test/fixtures/feature-compile-classpath/feature/build.gradle
@@ -1,0 +1,17 @@
+apply plugin: 'com.android.dynamic-feature'
+apply plugin: 'app.cash.better.dynamic.features'
+
+android {
+  namespace "app.cash.better.dynamic.features.integration.feature"
+
+  compileSdk 32
+}
+
+dependencies {
+  implementation project(":base")
+  compileOnly "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.0"
+}
+
+betterDynamicFeatures {
+  baseProject.set(project(":base"))
+}

--- a/gradle-plugin/src/test/fixtures/feature-compile-classpath/gradle.properties
+++ b/gradle-plugin/src/test/fixtures/feature-compile-classpath/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
+android.useAndroidX=true

--- a/gradle-plugin/src/test/fixtures/feature-compile-classpath/settings.gradle
+++ b/gradle-plugin/src/test/fixtures/feature-compile-classpath/settings.gradle
@@ -1,0 +1,4 @@
+apply from: "../settings.gradle"
+
+include ':base'
+include ':feature'

--- a/gradle-plugin/src/test/java/app/cash/better/dynamic/features/BetterDynamicFeaturesPluginTest.kt
+++ b/gradle-plugin/src/test/java/app/cash/better/dynamic/features/BetterDynamicFeaturesPluginTest.kt
@@ -485,6 +485,27 @@ class BetterDynamicFeaturesPluginTest {
     assertThat(result.output).contains("Updating the lockfile and running other tasks together is an error. Update the lockfile first, and then run your other tasks separately.")
   }
 
+  @Test fun `feature module compile classpath does not influence base module runtime classpath`() {
+    val integrationRoot = File("src/test/fixtures/feature-compile-classpath")
+    val baseProject = integrationRoot.resolve("base")
+    clearLockfile(baseProject)
+
+    val gradleRunner = GradleRunner.create()
+      .withCommonConfiguration(integrationRoot)
+      .cleaned()
+      .withArguments(":base:writeLockfile", "--stacktrace")
+
+    gradleRunner.build()
+
+    assertThat(baseProject.lockfile().readText()).contains(
+      """
+      |org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.0=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.0=debugRuntimeClasspath,releaseRuntimeClasspath
+      |org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.0=debugRuntimeClasspath,releaseRuntimeClasspath
+      """.trimMargin(),
+    )
+  }
+
   private fun clearLockfile(root: File) {
     root.lockfile().takeIf { it.exists() }?.delete()
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=app.cash.better.dynamic.features
-VERSION_NAME=0.1.0-alpha23
+VERSION_NAME=0.1.0-alpha25
 
 POM_URL=https://github.com/cashapp/better-dynamic-features/
 POM_SCM_URL=https://github.com/cashapp/better-dynamic-features/


### PR DESCRIPTION
Long story short: if the base module has a runtime dependency that was on the feature module's compile classpath then the dependency graph merger wouldn't recognize that the compile dependency shouldn't be added to base module's compile classpath locks.

In the new test fixture, coroutines is added as `runtimeOnly` on the base and `compileOnly` on the feature module so we should expect the lockfile to only include the runtime classpath locks.

This separates the handling of runtime and compile classpaths and then merges the final results to ensure correctness.