### PR TITLE
Merge compile and runtime versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=app.cash.better.dynamic.features
-VERSION_NAME=0.1.0-alpha26
+VERSION_NAME=0.1.0-alpha27
 
 POM_URL=https://github.com/cashapp/better-dynamic-features/
 POM_SCM_URL=https://github.com/cashapp/better-dynamic-features/


### PR DESCRIPTION
Turns out you can't use different dependency versions for compile and runtime in a single module