### PR TITLE
Fix version comparisons in lockfile generation

### DIFF
--- a/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/tasks/DependencyGraph.kt
+++ b/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/tasks/DependencyGraph.kt
@@ -2,11 +2,12 @@
 package app.cash.better.dynamic.features.tasks
 
 import com.squareup.moshi.JsonClass
+import org.gradle.util.internal.VersionNumber
 
 @JsonClass(generateAdapter = true)
 data class Node(
   val artifact: String,
-  val version: String,
+  val version: Version,
   val variants: Set<String>,
   val children: List<Node>,
   val isProjectModule: Boolean,
@@ -20,3 +21,12 @@ enum class DependencyType {
 
 @JsonClass(generateAdapter = true)
 data class NodeList(val nodes: List<Node>)
+
+@JsonClass(generateAdapter = true)
+@JvmInline
+value class Version(val string: String) : Comparable<Version> {
+  override fun compareTo(other: Version): Int =
+    VersionNumber.parse(string).compareTo(VersionNumber.parse(other.string))
+
+  override fun toString(): String = string
+}

--- a/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/tasks/DependencyGraphUtils.kt
+++ b/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/tasks/DependencyGraphUtils.kt
@@ -63,7 +63,7 @@ private fun mergeSingleTypeGraphs(
     .map { (_, entry) ->
       LockfileEntry(
         entry.artifact,
-        entry.version,
+        entry.version.toString(),
         entry.configurationNames,
       )
     }

--- a/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/tasks/DependencyGraphWriterTask.kt
+++ b/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/tasks/DependencyGraphWriterTask.kt
@@ -65,7 +65,7 @@ abstract class DependencyGraphWriterTask : DefaultTask() {
         val info = it.selected.moduleVersion!!
         Node(
           "${info.group}:${info.name}",
-          info.version,
+          Version(info.version),
           mutableSetOf(variant),
           children = buildDependencyGraph(it.selected.getDependenciesForVariant(it.resolvedVariant), variant, visited, type),
           isProjectModule = it.resolvedVariant.owner is ProjectComponentIdentifier,

--- a/gradle-plugin/src/test/java/app/cash/better/dynamic/features/BetterDynamicFeaturesPluginTest.kt
+++ b/gradle-plugin/src/test/java/app/cash/better/dynamic/features/BetterDynamicFeaturesPluginTest.kt
@@ -1,6 +1,7 @@
 // Copyright Square, Inc.
 package app.cash.better.dynamic.features
 
+import app.cash.better.dynamic.features.tasks.Version
 import com.google.common.truth.Truth.assertThat
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
@@ -551,6 +552,13 @@ class BetterDynamicFeaturesPluginTest {
       |org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.0=debugRuntimeClasspath,releaseRuntimeClasspath
       """.trimMargin(),
     )
+  }
+
+  @Test fun `semver comparison is correct`() {
+    val low = Version("2.8.7")
+    val high = Version("2.10.1")
+
+    assertThat(high).isGreaterThan(low)
   }
 
   private fun clearLockfile(root: File) {


### PR DESCRIPTION
Fixes #83 

Delegates the comparison to Gradle's internal `VersionNumber` class.