### PR TITLE
Bump to AGP 8.2.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-agp = "8.2.0"
-android-tools = "31.2.0" # agp version + 23.0.0
+agp = "8.2.1"
+android-tools = "31.2.1" # agp version + 23.0.0
 compilerTesting = "0.2.1"
 compose = "1.4.7"
 kotlin = "1.8.21"


### PR DESCRIPTION
Bump to the latest `8.2.1` version [release notes](https://androidstudio.googleblog.com/2024/01/android-studio-hedgehog-202311-patch-1.html)

Verified that both copied class didn't changed between `8.2.0` and `8.2.1`