### PR TITLE
Add a version skipping mechanism for the AGP patch

### DIFF
--- a/agp-patch/src/main/kotlin/app/cash/better/dynamic/features/AgpPatchPlugin.kt
+++ b/agp-patch/src/main/kotlin/app/cash/better/dynamic/features/AgpPatchPlugin.kt
@@ -26,7 +26,6 @@ class AgpPatchPlugin : Plugin<Project> {
 
     target.plugins.withId("com.android.application") {
       target.afterEvaluate {
-
         val agpVersion = Version.ANDROID_GRADLE_PLUGIN_VERSION
         // Skip the version check if we ignored the current AGP version!
         if (agpVersion in extension.ignoredVersions) {

--- a/agp-patch/src/main/kotlin/app/cash/better/dynamic/features/AgpPatchPlugin.kt
+++ b/agp-patch/src/main/kotlin/app/cash/better/dynamic/features/AgpPatchPlugin.kt
@@ -16,15 +16,28 @@
 package app.cash.better.dynamic.features
 
 import com.android.Version
+import com.android.build.gradle.internal.crash.afterEvaluate
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 class AgpPatchPlugin : Plugin<Project> {
   override fun apply(target: Project) {
+    val extension = target.extensions.create("betterDynamicFeaturesPatch", BetterDynamicFeaturesPatchExtension::class.java)
+
     target.plugins.withId("com.android.application") {
-      // Do a strict version check to ensure that our monkey-patching will work correctly.
-      check(Version.ANDROID_GRADLE_PLUGIN_VERSION == TARGET_AGP_VERSION) {
-        "This version of the Android Gradle Plugin (${Version.ANDROID_GRADLE_PLUGIN_VERSION}) is not supported by the better-dynamic-features plugin. Only version $TARGET_AGP_VERSION is supported."
+      target.afterEvaluate {
+
+        val agpVersion = Version.ANDROID_GRADLE_PLUGIN_VERSION
+        // Skip the version check if we ignored the current AGP version!
+        if (agpVersion in extension.ignoredVersions) {
+          target.logger.info("Version compatibility check for Android Gradle Plugin $agpVersion skipped.")
+          return@afterEvaluate
+        }
+
+        // Do a strict version check to ensure that our monkey-patching will work correctly.
+        check(agpVersion == TARGET_AGP_VERSION) {
+          "This version of the Android Gradle Plugin ($agpVersion) is not supported by the better-dynamic-features plugin. Only version $TARGET_AGP_VERSION is supported."
+        }
       }
     }
   }

--- a/agp-patch/src/main/kotlin/app/cash/better/dynamic/features/BetterDynamicFeaturesPatchExtension.kt
+++ b/agp-patch/src/main/kotlin/app/cash/better/dynamic/features/BetterDynamicFeaturesPatchExtension.kt
@@ -1,0 +1,9 @@
+package app.cash.better.dynamic.features
+
+open class BetterDynamicFeaturesPatchExtension {
+  internal val ignoredVersions = mutableSetOf<String>()
+
+  fun suppressVersionCheck(version: String) {
+    ignoredVersions += version
+  }
+}

--- a/agp-patch/src/main/kotlin/app/cash/better/dynamic/features/BetterDynamicFeaturesPatchExtension.kt
+++ b/agp-patch/src/main/kotlin/app/cash/better/dynamic/features/BetterDynamicFeaturesPatchExtension.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package app.cash.better.dynamic.features
 
 open class BetterDynamicFeaturesPatchExtension {


### PR DESCRIPTION
Usage: BDF targets 8.2.1 and you want to upgrade to 8.2.2 which you know is safe

```kotlin
betterDynamicFeaturesPatch {
  suppressVersionCheck("8.2.2")
}
```