### PR TITLE
Fix KSP configuration for flavored builds

### DIFF
--- a/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/BetterDynamicFeaturesPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/BetterDynamicFeaturesPlugin.kt
@@ -468,14 +468,8 @@ class BetterDynamicFeaturesPlugin : Plugin<Project> {
     }
   }
 
-  private fun kspTaskMatchesVariant(task: KspTask, variant: Variant): Boolean = task.name.contains(
-    variant.buildType!!,
-    ignoreCase = true,
-  ) || variant.productFlavors.any { (_, flavor) ->
-    task.name.contains(
-      flavor,
-      ignoreCase = true,
-    )
+  private fun kspTaskMatchesVariant(task: KspTask, variant: Variant): Boolean {
+    return task.name.contains(variant.name, ignoreCase = true) && !task.name.contains("UnitTest", ignoreCase = true)
   }
 
   companion object {


### PR DESCRIPTION
This fixes an issue where building on flavor variant (e.g. internalDebug) would cause other build tasks of release types of the same flavor to also be run (e.g. internalRelease).