### PR TITLE
Bump to AGP 8.4.1 and Gradle 8.7

### DIFF
--- a/agp-patch/src/main/kotlin/com/android/build/gradle/internal/DependencyConfigurator.kt
+++ b/agp-patch/src/main/kotlin/com/android/build/gradle/internal/DependencyConfigurator.kt
@@ -495,7 +495,7 @@ class DependencyConfigurator(
             experimentalPropertiesApiGenerator
               ?: project.dependencies.create(
                 projectServices.projectOptions.get(StringOption.ANDROID_PRIVACY_SANDBOX_SDK_API_GENERATOR)
-                  ?: "androidx.privacysandbox.tools:tools-apigenerator:1.0.0-alpha03"
+                    ?: MavenCoordinates.ANDROIDX_PRIVACY_SANDBOX_SDK_API_GENERATOR.toString()
               ) as Dependency
 
           val experimentalPropertiesRuntimeApigeneratorDependencies =
@@ -505,7 +505,7 @@ class DependencyConfigurator(
               ?: (projectServices.projectOptions
                 .get(StringOption.ANDROID_PRIVACY_SANDBOX_SDK_API_GENERATOR_GENERATED_RUNTIME_DEPENDENCIES)
                 ?.split(",")
-                ?: listOf("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")).map {
+                ?: listOf(MavenCoordinates.ORG_JETBRAINS_KOTLINX_KOTLINX_COROUTINES_ANDROID.toString())).map {
                   project.dependencies.create(it)
                 }
 
@@ -524,7 +524,7 @@ class DependencyConfigurator(
           params.bootstrapClasspath.from(bootstrapCreationConfig.fullBootClasspath)
 
           val kotlinCompiler = project.configurations.detachedConfiguration(
-            project.dependencies.create("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.10")
+                    project.dependencies.create(MavenCoordinates.KOTLIN_COMPILER.toString())
           )
           kotlinCompiler.isCanBeConsumed = false
           kotlinCompiler.isCanBeResolved = true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-agp = "8.3.2"               # keep in sync with android-tools
-android-tools = "31.3.2"    # = 23.0.0 + agp
+agp = "8.4.1"               # keep in sync with android-tools
+android-tools = "31.4.1"    # = 23.0.0 + agp
 compilerTesting = "0.2.1"
 compose = "1.4.7"
 kotlin = "1.8.21"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Oct 20 09:50:20 EDT 2022
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
AGP `8.4.x` requires at least Gradle `8.6`, bumping to the latest available.

Copied `DependencyConfigurator.kt` over but the other file hasn't changed since `8.3.2` so that's why I only have one of the two usual commits.