### PR TITLE
Bump to AGP 8.6.0

### DIFF
--- a/agp-patch/src/main/kotlin/com/android/build/gradle/internal/dependency/DexingTransform.kt
+++ b/agp-patch/src/main/kotlin/com/android/build/gradle/internal/dependency/DexingTransform.kt
@@ -470,7 +470,7 @@ object DexingRegistration {
             enableApiModeling = creationConfig.enableApiModeling,
             dependenciesClassesAreInstrumented = creationConfig.instrumentationCreationConfig?.dependenciesClassesAreInstrumented == true,
             asmTransformComponent = creationConfig.name.takeIf { creationConfig.instrumentationCreationConfig?.dependenciesClassesAreInstrumented == true },
-            useJacocoTransformInstrumentation = creationConfig.useJacocoTransformInstrumentation,
+            useJacocoTransformInstrumentation = creationConfig.requiresJacocoTransformation,
             enableDesugaring = needsDesugaring(creationConfig),
             needsClasspath = needsClasspath(creationConfig),
             useFullClasspath = useFullClasspath(creationConfig),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-agp = "8.5.1"               # keep in sync with android-tools
-android-tools = "31.5.1"    # = 23.0.0 + agp
+agp = "8.6.0"               # keep in sync with android-tools
+android-tools = "31.6.0"    # = 23.0.0 + agp
 compilerTesting = "0.2.1"
 compose = "1.5.14"
 kotlin = "1.9.24"


### PR DESCRIPTION
Requires `Android Studio Koala Feature Drop | 2024.1.2`