### PR TITLE
Bump to AGP 8.6.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-agp = "8.6.0"               # keep in sync with android-tools
-android-tools = "31.6.0"    # = 23.0.0 + agp
+agp = "8.6.1"               # keep in sync with android-tools
+android-tools = "31.6.1"    # = 23.0.0 + agp
 compilerTesting = "0.2.1"
 compose = "1.5.14"
 kotlin = "1.9.24"


### PR DESCRIPTION
Release notes: https://androidstudio.googleblog.com/2024/09/android-studio-koala-feature-drop.html
No changes to both AGP classes.
