### PR TITLE
Bump to AGP 8.8.x

### DIFF
--- a/agp-patch/src/main/kotlin/com/android/build/gradle/internal/DependencyConfigurator.kt
+++ b/agp-patch/src/main/kotlin/com/android/build/gradle/internal/DependencyConfigurator.kt
@@ -265,20 +265,21 @@ class DependencyConfigurator(
       AndroidArtifacts.TYPE_PLATFORM_ATTR
     )
 
-    val sharedLibSupport = projectOptions[BooleanOption.CONSUME_DEPENDENCIES_AS_SHARED_LIBRARIES]
+    val namespacedSharedLibSupport = projectOptions[BooleanOption.CONSUME_DEPENDENCIES_AS_SHARED_LIBRARIES]
+    val sharedLibSupport = projectOptions[BooleanOption.SUPPORT_OEM_TOKEN_LIBRARIES]
 
-        val libraryCategory = project.objects.named(Category::class.java, Category.LIBRARY)
-        for (transformTarget in AarTransform.getTransformTargets(aarOrJarTypeToConsume)) {
-            dependencies.registerTransform(
-                AarTransform::class.java
-            ) { spec ->
-                spec.from.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, AndroidArtifacts.ArtifactType.EXPLODED_AAR.type)
-                spec.from.attribute(Category.CATEGORY_ATTRIBUTE, libraryCategory)
-                spec.to.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, transformTarget.type)
-                spec.to.attribute(Category.CATEGORY_ATTRIBUTE, libraryCategory)
-                spec.parameters.projectName.setDisallowChanges(project.name)
-                spec.parameters.targetType.setDisallowChanges(transformTarget)
-                spec.parameters.sharedLibSupport.setDisallowChanges(sharedLibSupport)
+    val libraryCategory = project.objects.named(Category::class.java, Category.LIBRARY)
+    for (transformTarget in AarTransform.getTransformTargets(aarOrJarTypeToConsume, sharedLibSupport)) {
+        dependencies.registerTransform(
+            AarTransform::class.java
+        ) { spec ->
+            spec.from.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, AndroidArtifacts.ArtifactType.EXPLODED_AAR.type)
+            spec.from.attribute(Category.CATEGORY_ATTRIBUTE, libraryCategory)
+            spec.to.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, transformTarget.type)
+            spec.to.attribute(Category.CATEGORY_ATTRIBUTE, libraryCategory)
+            spec.parameters.projectName.setDisallowChanges(project.name)
+            spec.parameters.targetType.setDisallowChanges(transformTarget)
+            spec.parameters.namespacedSharedLibSupport.setDisallowChanges(namespacedSharedLibSupport)
       }
     }
     if (projectOptions[BooleanOption.PRECOMPILE_DEPENDENCIES_RESOURCES]) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-agp = "8.7.3"               # keep in sync with android-tools
-android-tools = "31.7.3"    # = 23.0.0 + agp
+agp = "8.8.0"               # keep in sync with android-tools
+android-tools = "31.8.0"    # = 23.0.0 + agp
 compilerTesting = "0.2.1"
 compose = "1.5.14"
 kotlin = "1.9.24"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Sep 17 07:31:50 EDT 2024
+#Tue Oct 29 10:05:49 EDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Bump to AGP 8.8.x and Gradle 8.10.2 (_required by AGP_)

release is stable: https://androidstudio.googleblog.com/2025/01/android-studio-ladybug-feature-drop.html