### PR TITLE
Bump to AGP 8.9.x and Gradle 8.12.1

### DIFF
--- a/agp-patch/src/main/kotlin/com/android/build/gradle/internal/DependencyConfigurator.kt
+++ b/agp-patch/src/main/kotlin/com/android/build/gradle/internal/DependencyConfigurator.kt
@@ -69,6 +69,7 @@ import com.android.build.gradle.internal.dsl.ModulePropertyKey
 import com.android.build.gradle.internal.dsl.ProductFlavor
 import com.android.build.gradle.internal.dsl.SigningConfig
 import com.android.build.gradle.internal.packaging.getDefaultDebugKeystoreSigningConfig
+import com.android.build.gradle.internal.profile.AnalyticsService
 import com.android.build.gradle.internal.publishing.AarOrJarTypeToConsume
 import com.android.build.gradle.internal.publishing.AndroidArtifacts
 import com.android.build.gradle.internal.res.namespaced.AutoNamespacePreProcessTransform
@@ -78,7 +79,7 @@ import com.android.build.gradle.internal.services.AndroidLocationsBuildService
 import com.android.build.gradle.internal.services.ProjectServices
 import com.android.build.gradle.internal.services.getBuildService
 import com.android.build.gradle.internal.signing.SigningConfigData
-import com.android.build.gradle.internal.tasks.AsarToApksTransform
+import com.android.build.gradle.internal.tasks.AsarToExtractedApksTransform
 import com.android.build.gradle.internal.tasks.AsarTransform
 import com.android.build.gradle.internal.tasks.factory.BootClasspathConfig
 import com.android.build.gradle.internal.utils.ATTR_ENABLE_CORE_LIBRARY_DESUGARING
@@ -660,9 +661,9 @@ class DependencyConfigurator(
                                         "Set the same signing config using experimental properties in each variant explicitly.")
                 }
             registerTransform(
-                    AsarToApksTransform::class.java,
+                    AsarToExtractedApksTransform::class.java,
                     AndroidArtifacts.ArtifactType.ANDROID_PRIVACY_SANDBOX_SDK_ARCHIVE,
-                    AndroidArtifacts.ArtifactType.ANDROID_PRIVACY_SANDBOX_SDK_APKS
+                    AndroidArtifacts.ArtifactType.ANDROID_PRIVACY_SANDBOX_EXTRACTED_SDK_APKS
             ) { params ->
                 projectServices.initializeAapt2Input(params.aapt2, task = null)
 
@@ -671,6 +672,7 @@ class DependencyConfigurator(
                         ArtifactsImpl(project,
                                 "global").get(InternalArtifactType.VALIDATE_SIGNING_CONFIG)
                 )
+                params.analyticsService.set(getBuildService<AnalyticsService, AnalyticsService.Params>(project.gradle.sharedServices))
             }
         }
         registerAsarToApksTransform(variants)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-agp = "8.8.1"               # keep in sync with android-tools
-android-tools = "31.8.1"    # = 23.0.0 + agp
+agp = "8.9.0"               # keep in sync with android-tools
+android-tools = "31.9.0"    # = 23.0.0 + agp
 compilerTesting = "0.2.1"
 compose = "1.5.14"
 kotlin = "1.9.24"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Oct 29 10:05:49 EDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Bump to AGP 8.9.x and Gradle 8.12.1 (8.11.1 required by AGP but decided to bump to latest)
No changes to DexingTransform's copy.

- [x] wait for stable release