### PR TITLE
Bump deprecated upload-artifact github action to v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         run: ./gradlew check --stacktrace
 
       - name: Store Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: error-report


### PR DESCRIPTION
Fixes https://github.com/cashapp/better-dynamic-features/actions/runs/13139015259/job/36661300990?pr=138#step:1:36