### PR TITLE
Support KSP integration for custom build types

### DIFF
--- a/gradle-plugin/src/test/fixtures/custom-build-type/base/build.gradle
+++ b/gradle-plugin/src/test/fixtures/custom-build-type/base/build.gradle
@@ -1,0 +1,24 @@
+apply plugin: 'com.android.application'
+apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'com.google.devtools.ksp'
+apply plugin: 'app.cash.better.dynamic.features'
+
+android {
+  namespace "app.cash.better.dynamic.features.integration"
+
+  compileSdk 32
+  defaultConfig {
+    minSdk = 24
+
+    versionCode 1
+  }
+
+  buildTypes {
+    staging {
+      initWith debug
+      matchingFallbacks = ['debug']
+    }
+  }
+
+  dynamicFeatures = [':feature']
+}

--- a/gradle-plugin/src/test/fixtures/custom-build-type/base/src/main/AndroidManifest.xml
+++ b/gradle-plugin/src/test/fixtures/custom-build-type/base/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest />

--- a/gradle-plugin/src/test/fixtures/custom-build-type/build.gradle
+++ b/gradle-plugin/src/test/fixtures/custom-build-type/build.gradle
@@ -1,0 +1,13 @@
+buildscript {
+  apply from: "${projectDir.absolutePath}/../buildscript.gradle"
+}
+
+allprojects {
+  repositories {
+    maven {
+      url "file://${rootDir}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+}

--- a/gradle-plugin/src/test/fixtures/custom-build-type/feature/build.gradle
+++ b/gradle-plugin/src/test/fixtures/custom-build-type/feature/build.gradle
@@ -1,0 +1,28 @@
+apply plugin: 'com.android.dynamic-feature'
+apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'com.google.devtools.ksp'
+apply plugin: 'app.cash.better.dynamic.features'
+
+android {
+  namespace "app.cash.better.dynamic.features.integration.feature"
+
+  compileSdk 32
+  defaultConfig {
+    minSdk = 24
+  }
+
+  buildTypes {
+    staging {
+      initWith debug
+      matchingFallbacks = ['debug']
+    }
+  }
+}
+
+dependencies {
+  implementation project(":base")
+}
+
+betterDynamicFeatures {
+  baseProject.set(project(":base"))
+}

--- a/gradle-plugin/src/test/fixtures/custom-build-type/feature/src/main/AndroidManifest.xml
+++ b/gradle-plugin/src/test/fixtures/custom-build-type/feature/src/main/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:dist="http://schemas.android.com/apk/distribution">
+    <dist:module
+        dist:instant="false"
+        dist:title="Feature">
+        <dist:delivery>
+            <dist:install-time />
+        </dist:delivery>
+        <dist:fusing dist:include="true" />
+    </dist:module>
+</manifest>

--- a/gradle-plugin/src/test/fixtures/custom-build-type/gradle.properties
+++ b/gradle-plugin/src/test/fixtures/custom-build-type/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
+android.useAndroidX=true

--- a/gradle-plugin/src/test/fixtures/custom-build-type/settings.gradle
+++ b/gradle-plugin/src/test/fixtures/custom-build-type/settings.gradle
@@ -1,0 +1,4 @@
+apply from: "../settings.gradle"
+
+include ':base'
+include ':feature'

--- a/gradle-plugin/src/test/java/app/cash/better/dynamic/features/BetterDynamicFeaturesPluginTest.kt
+++ b/gradle-plugin/src/test/java/app/cash/better/dynamic/features/BetterDynamicFeaturesPluginTest.kt
@@ -850,6 +850,17 @@ class BetterDynamicFeaturesPluginTest {
     )
   }
 
+  @Test fun `custom build type is acknowledged`() {
+    val integrationRoot = File("src/test/fixtures/custom-build-type")
+
+    val gradleRunner = GradleRunner.create()
+      .withCommonConfiguration(integrationRoot)
+      .cleaned()
+      .withArguments(":base:assembleStaging", "--stacktrace")
+
+    gradleRunner.build()
+  }
+
   private fun clearLockfile(root: File) {
     root.lockfile().takeIf { it.exists() }?.delete()
   }

--- a/gradle-plugin/src/test/java/app/cash/better/dynamic/features/BetterDynamicFeaturesPluginTest.kt
+++ b/gradle-plugin/src/test/java/app/cash/better/dynamic/features/BetterDynamicFeaturesPluginTest.kt
@@ -856,9 +856,13 @@ class BetterDynamicFeaturesPluginTest {
     val gradleRunner = GradleRunner.create()
       .withCommonConfiguration(integrationRoot)
       .cleaned()
-      .withArguments(":base:assembleStaging", "--stacktrace")
+      .withArguments(":base:writeLockfile")
 
+    // Generate lockfile first, and then run assemble task
     gradleRunner.build()
+    val result = gradleRunner.withArguments(":base:assembleStaging", "--stacktrace").build()
+
+    assertThat(result.output).contains("BUILD SUCCESSFUL")
   }
 
   private fun clearLockfile(root: File) {


### PR DESCRIPTION
Instead of hardcoding the debug and release build types for KSP, do it for _all_ variants, potentially including a custom build type.

Proposal to resolve #145.