### PR TITLE
Bump to AGP 8.10.x

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-agp = "8.9.0"               # keep in sync with android-tools
-android-tools = "31.9.0"    # = 23.0.0 + agp
+agp = "8.10.0-beta01"               # keep in sync with android-tools
+android-tools = "31.10.0-beta01"    # = 23.0.0 + agp
 compilerTesting = "0.2.1"
 compose = "1.5.14"
 kotlin = "1.9.24"


### PR DESCRIPTION
- [ ] wait for stable release

No changes to both copied class from AGP.