### PR TITLE
Delete unused toolchain plugin

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -6,10 +6,6 @@ pluginManagement {
   }
 }
 
-plugins {
-  id "org.gradle.toolchains.foojay-resolver-convention" version "0.5.0"
-}
-
 dependencyResolutionManagement {
   repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
   repositories {


### PR DESCRIPTION
Noticed this plugin due to the renovate bump https://github.com/cashapp/better-dynamic-features/pull/175
Doesn't seem to be used so deleting instead.