### PR TITLE
Bump support for AGP 8.12.0

### DIFF
--- a/agp-patch/src/main/kotlin/com/android/build/gradle/internal/DependencyConfigurator.kt
+++ b/agp-patch/src/main/kotlin/com/android/build/gradle/internal/DependencyConfigurator.kt
@@ -981,7 +981,7 @@ class DependencyConfigurator(
             AndroidArtifacts.ArtifactType.FILTERED_PROGUARD_RULES.type
           )
         reg.parameters { params: FilterShrinkerRulesTransform.Parameters ->
-            params.shrinker.set(ShrinkerVersion.R8)
+            params.shrinkerVersion.set(ShrinkerVersion.R8)
             params.projectName.set(project.name)
         }
       }

--- a/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/tasks/CheckExternalResourcesTask.kt
+++ b/gradle-plugin/src/main/kotlin/app/cash/better/dynamic/features/tasks/CheckExternalResourcesTask.kt
@@ -148,7 +148,7 @@ abstract class CheckExternalResourcesTask : DefaultTask() {
     val localStyles = localResources.files
       .filter {
         // Exclude the resources we generate
-        "ExternalResources" !in it.path && it.exists()
+        "betterDynamicFeatures" !in it.path && it.exists()
       }
       .flatMap { directory -> directory.walk() } // Grab every .xml file from each res/ directory
       .filter { it.extension == "xml" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-agp = "8.11.1"               # keep in sync with android-tools
-android-tools = "31.11.1"    # = 23.0.0 + agp
+agp = "8.12.0"               # keep in sync with android-tools
+android-tools = "31.12.0"    # = 23.0.0 + agp
 compilerTesting = "0.7.1"
 kotlin = "2.1.20"
 kotlinPoet = "1.13.1"


### PR DESCRIPTION
* Was a minor change in the output directory of our generated external resources